### PR TITLE
fix: Makefile utils for Darwin

### DIFF
--- a/make/platform.mk
+++ b/make/platform.mk
@@ -1,6 +1,6 @@
 OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
 ifeq ($(OS), darwin)
-  BREW_PREFIX := $(shell brew --prefix &>/dev/null)
+  BREW_PREFIX := $(shell brew --prefix 2>/dev/null)
   ifeq ($(BREW_PREFIX),)
     $(error Unable to discover brew prefix - do you have brew installed? See https://brew.sh/ for details of how to install)
   endif

--- a/make/shell.mk
+++ b/make/shell.mk
@@ -1,4 +1,5 @@
-SHELL := /bin/bash
+# This is compatible with Darwin, see https://itnext.io/upgrading-bash-on-macos-7138bd1066ba
+SHELL := /usr/bin/env bash
 .SHELLFLAGS = -euo pipefail -c
 
 # We need to explicitly get the bash version via shell command here because the user could be


### PR DESCRIPTION
1. I have `bash` that I installed with `brew`
```
➜  mindthegap git:(dkoshkin/darwin-fixes) bash --version
GNU bash, version 5.1.12(1)-release (x86_64-apple-darwin20.6.0)
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

But `SHELL := /bin/bash` uses the default old version that comes with Darwin.

---

2. I think you meant to discard just stderr instead of `brew --prefix &>/dev/null`? 
