### PR TITLE
fix: Embed default policy in binary

### DIFF
--- a/skopeo/default-policy.json
+++ b/skopeo/default-policy.json
@@ -1,0 +1,14 @@
+{
+  "default": [
+      {
+          "type": "insecureAcceptAnything"
+      }
+  ],
+  "transports":
+      {
+          "docker-daemon":
+              {
+                  "": [{"type":"insecureAcceptAnything"}]
+              }
+      }
+}


### PR DESCRIPTION
Works around the error `Error loading trust policy: open
/etc/containers/policy.json: no such file or directory`.
