### PR TITLE
feat: Add serve image-bundle subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ mindthegap push image-bundle --image-bundle <path/to/images.tar> \
 
 All images in the image bundle tar file will be pushed to the target docker registry.
 
+### Serving an image bundle
+
+```shell
+mindthegap serve image-bundle --image-bundle <path/to/images.tar> \
+  [--listen-address <listen.address>] \
+  [--listen-port <listen.port>]
+```
+
+Start a Docker registry serving the contents of the image bundle. Note that he Docker registry will
+be in read-only mode to reflect the source of the data being a static tarball so pushes to this
+registry will fail.
+
 ## How does it work?
 
 `mindthegap` starts up a [Docker registry](https://docs.docker.com/registry/)

--- a/cmd/push/imagebundle/image_bundle.go
+++ b/cmd/push/imagebundle/image_bundle.go
@@ -73,7 +73,7 @@ func NewCommand(ioStreams genericclioptions.IOStreams) *cobra.Command {
 			statusLogger.End(true)
 
 			statusLogger.Start("Starting temporary Docker registry")
-			reg, err := registry.NewRegistry(registry.Config{StorageDirectory: tempDir})
+			reg, err := registry.NewRegistry(registry.Config{StorageDirectory: tempDir, ReadOnly: true})
 			if err != nil {
 				statusLogger.End(false)
 				return fmt.Errorf("failed to create local Docker registry: %w", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/mesosphere/mindthegap/cmd/create"
 	"github.com/mesosphere/mindthegap/cmd/push"
+	"github.com/mesosphere/mindthegap/cmd/serve"
 )
 
 func NewCommand(in io.Reader, out, errOut io.Writer) *cobra.Command {
@@ -33,6 +34,7 @@ func NewCommand(in io.Reader, out, errOut io.Writer) *cobra.Command {
 
 	rootCmd.AddCommand(create.NewCommand(ioStreams))
 	rootCmd.AddCommand(push.NewCommand(ioStreams))
+	rootCmd.AddCommand(serve.NewCommand(ioStreams))
 
 	return rootCmd
 }

--- a/cmd/serve/imagebundle/image_bundle.go
+++ b/cmd/serve/imagebundle/image_bundle.go
@@ -1,0 +1,91 @@
+// Copyright 2021 D2iQ, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package imagebundle
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/mesosphere/dkp-cli/runtime/cli"
+	"github.com/mesosphere/dkp-cli/runtime/cmd/log"
+	"github.com/mholt/archiver/v3"
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/klog/v2"
+
+	"github.com/mesosphere/mindthegap/docker/registry"
+)
+
+func NewCommand(ioStreams genericclioptions.IOStreams) *cobra.Command {
+	var (
+		imageBundleFile string
+		listenAddress   string
+		listenPort      uint16
+	)
+
+	cmd := &cobra.Command{
+		Use: "image-bundle",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			klog.SetOutput(ioStreams.ErrOut)
+			logger := log.NewLogger(ioStreams.ErrOut)
+			statusLogger := cli.StatusForLogger(logger)
+
+			statusLogger.Start("Creating temporary directory")
+			tempDir, err := os.MkdirTemp("", ".image-bundle-*")
+			if err != nil {
+				statusLogger.End(false)
+				return fmt.Errorf("failed to create temporary directory: %w", err)
+			}
+			defer os.RemoveAll(tempDir)
+			statusLogger.End(true)
+
+			statusLogger.Start("Unarchiving image bundle")
+			err = archiver.Unarchive(imageBundleFile, tempDir)
+			if err != nil {
+				statusLogger.End(false)
+				return fmt.Errorf("failed to unarchive image bundle: %w", err)
+			}
+			statusLogger.End(true)
+
+			statusLogger.Start("Creating temporary Docker registry")
+			reg, err := registry.NewRegistry(registry.Config{
+				StorageDirectory: tempDir,
+				ReadOnly:         true,
+				Host:             listenAddress,
+				Port:             listenPort,
+			})
+			if err != nil {
+				statusLogger.End(false)
+				return fmt.Errorf("failed to create local Docker registry: %w", err)
+			}
+			statusLogger.End(true)
+			fmt.Fprintf(ioStreams.Out, "Listening on %s\n", reg.Address())
+			if err := reg.ListenAndServe(); err != nil {
+				statusLogger.End(false)
+				fmt.Fprintf(ioStreams.ErrOut, "error serving Docker registry: %v\n", err)
+				os.Exit(2)
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&imageBundleFile, "image-bundle", "", "Tarball containing list of images to push")
+	_ = cmd.MarkFlagRequired("image-bundle")
+	cmd.Flags().StringVar(&listenAddress, "listen-address", "localhost", "Address to list on")
+	cmd.Flags().Uint16Var(&listenPort, "listen-port", 0, "Port to listen on (0 means use any free port)")
+
+	return cmd
+}

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -1,0 +1,31 @@
+// Copyright 2021 D2iQ, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package serve
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	"github.com/mesosphere/mindthegap/cmd/serve/imagebundle"
+)
+
+func NewCommand(ioStreams genericclioptions.IOStreams) *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "serve",
+	}
+
+	cmd.AddCommand(imagebundle.NewCommand(ioStreams))
+	return cmd
+}


### PR DESCRIPTION
This commit adds a new subcommand that starts a docker registry serving the
images from the specified bundle.
