### PR TITLE
fix: comments in  skopeo policy.json

### DIFF
--- a/skopeo/default-policy.json
+++ b/skopeo/default-policy.json
@@ -1,6 +1,3 @@
-// Copyright 2021 D2iQ, Inc. All rights reserved.
-// SPDX-License-Identifier: Apache-2.0
-
 {
   "default": [
       {


### PR DESCRIPTION
Fixes issue
```
➜  dist/mindthegap_darwin_amd64/mindthegap create image-bundle --images-file images-example.yaml
 ✓ Checking if output file already exists
 ✓ Parsing image bundle config
 ✓ Creating temporary directory
 ✓ Starting temporary Docker registry
⢄⡱ Copying k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8 (platforms: [linux/amd64]) I0104 09:46:39.182417   19850 image_bundle.go:176] time="2022-01-04T09:46:39-08:00" level=fatal msg="Error loading trust policy: invalid policy in \"/var/folders/cf/02pp6nwj3sg15xdml78ytqfc0000gq/T/skopeo-2928207020/policy.json\": invalid character '/' looking for beginning of value"
 ✗ Copying k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.8 (platforms: [linux/amd64])
Error: exit status 1
```