### PR TITLE
feat: Support optional TLS when serving docker registry

### DIFF
--- a/cmd/serve/imagebundle/image_bundle.go
+++ b/cmd/serve/imagebundle/image_bundle.go
@@ -19,6 +19,8 @@ func NewCommand(out output.Output) *cobra.Command {
 		imageBundleFile string
 		listenAddress   string
 		listenPort      uint16
+		tlsCertificate  string
+		tlsKey          string
 	)
 
 	cmd := &cobra.Command{
@@ -47,6 +49,10 @@ func NewCommand(out output.Output) *cobra.Command {
 				ReadOnly:         true,
 				Host:             listenAddress,
 				Port:             listenPort,
+				TLS: registry.TLS{
+					Certificate: tlsCertificate,
+					Key:         tlsKey,
+				},
 			})
 			if err != nil {
 				out.EndOperation(false)
@@ -67,6 +73,8 @@ func NewCommand(out output.Output) *cobra.Command {
 	_ = cmd.MarkFlagRequired("image-bundle")
 	cmd.Flags().StringVar(&listenAddress, "listen-address", "localhost", "Address to list on")
 	cmd.Flags().Uint16Var(&listenPort, "listen-port", 0, "Port to listen on (0 means use any free port)")
+	cmd.Flags().StringVar(&tlsCertificate, "tls-cert-file", "", "TLS certificate file")
+	cmd.Flags().StringVar(&tlsKey, "tls-private-key-file", "", "TLS private key file")
 
 	return cmd
 }

--- a/docker/registry/registry_test.go
+++ b/docker/registry/registry_test.go
@@ -1,0 +1,83 @@
+// Copyright 2021 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package registry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	configWithoutTLS = `
+version: 0.1
+storage:
+  filesystem:
+    rootdirectory: /tmp
+  maintenance:
+    uploadpurging:
+      enabled: false
+    readonly:
+      enabled: true
+http:
+  net: tcp
+  addr: 0.0.0.0:5000
+log:
+  accesslog:
+    disabled: true
+  level: error
+`
+
+	configWithTLS = `
+version: 0.1
+storage:
+  filesystem:
+    rootdirectory: /tmp
+  maintenance:
+    uploadpurging:
+      enabled: false
+    readonly:
+      enabled: true
+http:
+  net: tcp
+  addr: 0.0.0.0:5000
+  tls:
+    certificate: /tmp/tls.cert
+    key: /tmp/tls.key
+log:
+  accesslog:
+    disabled: true
+  level: error
+`
+)
+
+func Test_registryConfiguration_withoutTLS(t *testing.T) {
+	c := Config{
+		StorageDirectory: "/tmp",
+		Host:             "0.0.0.0",
+		Port:             5000,
+		ReadOnly:         true,
+	}
+
+	config, err := registryConfiguration(c)
+	require.NoError(t, err)
+	require.Equal(t, configWithoutTLS, config)
+}
+
+func Test_registryConfiguration_withTLS(t *testing.T) {
+	c := Config{
+		StorageDirectory: "/tmp",
+		Host:             "0.0.0.0",
+		Port:             5000,
+		ReadOnly:         true,
+		TLS: TLS{
+			Certificate: "/tmp/tls.cert",
+			Key:         "/tmp/tls.key",
+		},
+	}
+
+	config, err := registryConfiguration(c)
+	require.NoError(t, err)
+	require.Equal(t, configWithTLS, config)
+}


### PR DESCRIPTION
New flags `--tls-cert-file` and `--tls-private-key-file` to support serving the docker registry with TLS enabled.

Tested creating a registry:
```
● mindthegap-registry.service - Run a docker registry using mindthegap
   Loaded: loaded (/usr/lib/systemd/system/mindthegap-registry.service; enabled; vendor preset: disabled)
   Active: active (running) since Wed 2022-01-26 01:06:31 UTC; 6min ago
 Main PID: 21681 (mindthegap)
    Tasks: 10
   Memory: 1.5G
   CGroup: /system.slice/mindthegap-registry.service
           └─21681 /home/centos/mindthegap serve image-bundle --image-bundle /home/centos/images.tar --listen-address 10.0.82.168 --listen-port 5000 --tls-cert-file /home/centos/registry/certs/server.crt --tls-private-key-file /home/centos/registry/certs/server.key

Jan 26 01:06:31 ip-10-0-82-168.us-west-2.compute.internal systemd[1]: Started Run a docker registry using mindthegap.
Jan 26 01:06:31 ip-10-0-82-168.us-west-2.compute.internal mindthegap[21681]: 2022-01-26 01:06:31 INF  • Creating temporary directory...
Jan 26 01:06:31 ip-10-0-82-168.us-west-2.compute.internal mindthegap[21681]: 2022-01-26 01:06:31 INF  ✓ Creating temporary directory
Jan 26 01:06:31 ip-10-0-82-168.us-west-2.compute.internal mindthegap[21681]: 2022-01-26 01:06:31 INF  • Unarchiving image bundle...
Jan 26 01:06:32 ip-10-0-82-168.us-west-2.compute.internal mindthegap[21681]: 2022-01-26 01:06:32 INF  ✓ Unarchiving image bundle
Jan 26 01:06:32 ip-10-0-82-168.us-west-2.compute.internal mindthegap[21681]: 2022-01-26 01:06:32 INF  • Creating temporary Docker registry...
Jan 26 01:06:32 ip-10-0-82-168.us-west-2.compute.internal mindthegap[21681]: 2022-01-26 01:06:32 INF  ✓ Creating temporary Docker registry
Jan 26 01:06:32 ip-10-0-82-168.us-west-2.compute.internal mindthegap[21681]: 2022-01-26 01:06:32 INF Listening on 10.0.82.168:5000
```

And pulled the image:
```
[centos@ip-10-0-82-168 ~]$ docker pull 10.0.82.168:5000/bitnami/kubectl:latest
latest: Pulling from bitnami/kubectl
Digest: sha256:919c1ec5bbfcf9b85c6beb069bdbd979643da6fde89a1689657c1062ca80776e
Status: Image is up to date for 10.0.82.168:5000/bitnami/kubectl:latest
```