### PR TITLE
feat: Gzip image bundle tarball

### DIFF
--- a/cmd/create/imagebundle/image_bundle.go
+++ b/cmd/create/imagebundle/image_bundle.go
@@ -209,7 +209,7 @@ func NewCommand(out output.Output) *cobra.Command {
 	_ = cmd.MarkFlagRequired("images-file")
 	cmd.Flags().Var(newPlatformSlicesValue([]platform{{os: "linux", arch: "amd64"}}, &platforms), "platform",
 		"platforms to download images (required format: <os>/<arch>[/<variant>])")
-	cmd.Flags().StringVar(&outputFile, "output-file", "images.tar", "Output file to write image bundle to")
+	cmd.Flags().StringVar(&outputFile, "output-file", "images.tar.gz", "Output file to write image bundle to")
 	cmd.Flags().BoolVar(&overwrite, "overwrite", false, "Overwrite image bundle file if it already exists")
 
 	return cmd


### PR DESCRIPTION
In reality, this makes no difference because the contents
is already compressed by virtue of being built via docker registry,
but having a GZ extension improves the UX and prevents users from
thinking they can make it smaller by gzipping it.
