### PR TITLE
fix: Fix registry log in error checking

### DIFF
--- a/skopeo/skopeo.go
+++ b/skopeo/skopeo.go
@@ -244,7 +244,7 @@ func (r *Runner) AttemptToLoginToRegistry(ctx context.Context, registryName stri
 	if err == nil {
 		return getLoginStdout, getLoginStderr, nil
 	}
-	if err != nil && !strings.Contains(string(getLoginStdout), fmt.Sprintf("not logged into %s", registryName)) {
+	if err != nil && !strings.Contains(string(getLoginStderr), fmt.Sprintf("not logged into %s", registryName)) {
 		return getLoginStdout, getLoginStderr, fmt.Errorf("failed to check if already logged in to %s: %w", registryName, err)
 	}
 


### PR DESCRIPTION
The string we want to check is in stderr
```
[centos@ip-172-31-17-125 ~]$ /home/centos/mindthegap create image-bundle --images-file images.txt
 ✓ Checking if output file already exists
 ✓ Parsing image bundle config
 ✓ Creating temporary directory
 ✓ Starting temporary Docker registry
---skopeo stdout---:

---skopeo stderr---:
time="2022-01-26T16:28:19Z" level=fatal msg="not logged into gcr.io"

error logging in to registry: failed to check if already logged in to gcr.io: exit status 1
```