### PR TITLE
feat: add command descriptions

### DIFF
--- a/cmd/create/create.go
+++ b/cmd/create/create.go
@@ -13,7 +13,8 @@ import (
 
 func NewCommand(out output.Output) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "create",
+		Use:   "create",
+		Short: "Create an tar.gz image or helm bundle",
 	}
 
 	cmd.AddCommand(imagebundle.NewCommand(out))

--- a/cmd/create/helmbundle/helm_bundle.go
+++ b/cmd/create/helmbundle/helm_bundle.go
@@ -27,7 +27,8 @@ func NewCommand(out output.Output) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use: "helm-bundle",
+		Use:   "helm-bundle",
+		Short: "Create a tar.gz helm bundle",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !overwrite {
 				out.StartOperation("Checking if output file already exists")

--- a/cmd/create/imagebundle/image_bundle.go
+++ b/cmd/create/imagebundle/image_bundle.go
@@ -30,7 +30,8 @@ func NewCommand(out output.Output) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use: "image-bundle",
+		Use:   "image-bundle",
+		Short: "Create a tar.gz image bundle",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !overwrite {
 				out.StartOperation("Checking if output file already exists")

--- a/cmd/importcmd/imagebundle/image_bundle.go
+++ b/cmd/importcmd/imagebundle/image_bundle.go
@@ -26,7 +26,8 @@ func NewCommand(out output.Output) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use: "image-bundle",
+		Use:   "image-bundle",
+		Short: "Import images from an image bundle into Containerd",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cleaner := cleanup.NewCleaner()
 			defer cleaner.Cleanup()

--- a/cmd/importcmd/import.go
+++ b/cmd/importcmd/import.go
@@ -12,7 +12,8 @@ import (
 
 func NewCommand(out output.Output) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "import",
+		Use:   "import",
+		Short: "Import images from an image bundle into Containerd",
 	}
 
 	cmd.AddCommand(imagebundle.NewCommand(out))

--- a/cmd/push/imagebundle/image_bundle.go
+++ b/cmd/push/imagebundle/image_bundle.go
@@ -27,7 +27,8 @@ func NewCommand(out output.Output) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use: "image-bundle",
+		Use:   "image-bundle",
+		Short: "Push images from an image bundle into an existing image registry",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cleaner := cleanup.NewCleaner()
 			defer cleaner.Cleanup()

--- a/cmd/push/push.go
+++ b/cmd/push/push.go
@@ -12,7 +12,8 @@ import (
 
 func NewCommand(out output.Output) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "push",
+		Use:   "push",
+		Short: "Push images from an image bundle into an existing image registry",
 	}
 
 	cmd.AddCommand(imagebundle.NewCommand(out))

--- a/cmd/serve/helmbundle/helm_bundle.go
+++ b/cmd/serve/helmbundle/helm_bundle.go
@@ -29,7 +29,8 @@ func NewCommand(out output.Output) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use: "helm-bundle",
+		Use:   "helm-bundle",
+		Short: "Serve a helm chart repository",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cleaner := cleanup.NewCleaner()
 			defer cleaner.Cleanup()

--- a/cmd/serve/imagebundle/image_bundle.go
+++ b/cmd/serve/imagebundle/image_bundle.go
@@ -25,7 +25,8 @@ func NewCommand(out output.Output) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use: "image-bundle",
+		Use:   "image-bundle",
+		Short: "Serve an image registry",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cleaner := cleanup.NewCleaner()
 			defer cleaner.Cleanup()

--- a/cmd/serve/serve.go
+++ b/cmd/serve/serve.go
@@ -13,7 +13,8 @@ import (
 
 func NewCommand(out output.Output) *cobra.Command {
 	cmd := &cobra.Command{
-		Use: "serve",
+		Use:   "serve",
+		Short: "Serve an image registry or a helm chart repository",
 	}
 
 	cmd.AddCommand(imagebundle.NewCommand(out))


### PR DESCRIPTION
```
➜  mindthegap --help
Usage:
  mindthegap [command]

Available Commands:
  completion       Generate the autocompletion script for the specified shell
  create           Create an tar.gz image or helm bundle
  help             Help about any command
  import           Import images from an image bundle into Containerd
  push             Push images from an image bundle into an existing image registry
  serve            Serve an image registry or a helm chart repository
  version          Print version information

Flags:
  -h, --help          Help for mindthegap
  -v, --verbose int   Output verbosity

Use "mindthegap [command] --help" for more information about a command.
```

```
➜  mindthegap create --help
Create an tar.gz image or helm bundle

Usage:
  mindthegap create [command]

Available Commands:
  helm-bundle  Create a tar.gz helm bundle
  image-bundle Create a tar.gz image bundle

Flags:
  -h, --help   Help for create

Global Flags:
  -v, --verbose int   Output verbosity

Use "mindthegap create [command] --help" for more information about a command.
```

```
➜  mindthegap import --help
Import images from an image bundle into Containerd

Usage:
  mindthegap import [command]

Available Commands:
  image-bundle Import images from an image bundle into Containerd

Flags:
  -h, --help   Help for import

Global Flags:
  -v, --verbose int   Output verbosity

Use "mindthegap import [command] --help" for more information about a command.
```

```
➜  mindthegap push --help
Push images from an image bundle into an existing image registry

Usage:
  mindthegap push [command]

Available Commands:
  image-bundle Push images from an image bundle into an existing image registry

Flags:
  -h, --help   Help for push

Global Flags:
  -v, --verbose int   Output verbosity

Use "mindthegap push [command] --help" for more information about a command.
```

```
➜  mindthegap serve --help
Serve an image registry or a helm chart repository

Usage:
  mindthegap serve [command]

Available Commands:
  helm-bundle  Serve a helm chart repository
  image-bundle Serve an image registry

Flags:
  -h, --help   Help for serve

Global Flags:
  -v, --verbose int   Output verbosity

Use "mindthegap serve [command] --help" for more information about a command.
```
