### PR TITLE
fix: commitDate in goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -32,7 +32,7 @@ builds:
     ldflags:
       - -s
       - -w
-      - -X 'github.com/mesosphere/dkp-cli-runtime/core/cmd/version.buildDate={{ .CommitDate }}'
+      - -X 'github.com/mesosphere/dkp-cli-runtime/core/cmd/version.commitDate={{ .CommitDate }}'
       - -X 'github.com/mesosphere/dkp-cli-runtime/core/cmd/version.gitCommit={{ .FullCommit }}'
       - -X 'github.com/mesosphere/dkp-cli-runtime/core/cmd/version.gitTreeState={{ .Env.GIT_TREE_STATE }}'
       - -X 'github.com/mesosphere/dkp-cli-runtime/core/cmd/version.gitVersion=v{{ trimprefix .Version "v" }}'


### PR DESCRIPTION
Noticed that konvoy and here had an incorrect `commitDate: "1970-01-01T00:00:00Z"`:
```
➜ ./dkp version -o yaml
diagnose:
  commitDate: "2022-03-21T16:52:29Z"
  compiler: gc
  gitCommit: 947e77ab077fab6f1cd528421cae7173ef08efd2
  gitTreeState: ""
  gitVersion: v0.0.0-dev.0
  goVersion: go1.17.6
  major: "0"
  minor: "0"
  platform: darwin/amd64
dkp:
  commitDate: "2022-04-04T00:51:14Z"
  compiler: gc
  gitCommit: 776919234cb227be7a1961fb37995a82ef1b4f28
  gitTreeState: ""
  gitVersion: v0.0.0-dev.0
  goVersion: go1.17.8
  major: "0"
  minor: "0"
  platform: darwin/amd64
kommander:
  commitDate: "2022-04-01T18:45:56Z"
  compiler: gc
  gitCommit: a73ad71be53f31a48f81c1c6fdc42b15c909e52a
  gitTreeState: ""
  gitVersion: v2.2.0-dev
  goVersion: go1.17.8
  major: "2"
  minor: "2"
  platform: darwin/amd64
konvoy:
  commitDate: "1970-01-01T00:00:00Z"
  compiler: gc
  gitCommit: 31dda110fe0483dc753de8500be218fd8e1d6bb0
  gitTreeState: ""
  gitVersion: v0.0.0-dev.0
  goVersion: go1.17.8
  major: "0"
  minor: "0"
  platform: darwin/amd64
mindthegap:
  commitDate: "1970-01-01T00:00:00Z"
  compiler: gc
  gitCommit: 51c911c08ab6837b70942f87648cc99aca14722c
  gitTreeState: ""
  gitVersion: v0.6.9
  goVersion: go1.17.8
  major: "0"
  minor: "6"
  platform: darwin/amd64
```