### PR TITLE
fix: prevent 404 on ECR during image creation

### DIFF
--- a/cmd/create/imagebundle/image_bundle.go
+++ b/cmd/create/imagebundle/image_bundle.go
@@ -147,6 +147,7 @@ func NewCommand(out output.Output) *cobra.Command {
 						srcImageManifestList, skopeoStdout, skopeoStderr, err := skopeoRunner.InspectManifest(
 							context.Background(),
 							fmt.Sprintf("%s%s", srcSkopeoScheme, srcImageName),
+							skopeo.NoTags(),
 						)
 						if err != nil {
 							srcSkopeoScheme = "docker-daemon:"

--- a/skopeo/skopeo.go
+++ b/skopeo/skopeo.go
@@ -77,6 +77,12 @@ func All() SkopeoOption {
 	}
 }
 
+func NoTags() SkopeoOption {
+	return func() string {
+		return "--no-tags"
+	}
+}
+
 func IndexOnly() SkopeoOption {
 	return func() string {
 		return "--multi-arch=index-only"


### PR DESCRIPTION
When using the inspect function on ECR repositories, it fails with an ominous 404.
https://github.com/containers/skopeo/issues/1230

This skips all extended tag listing -- we are happy with the one we asked for which IIUC should not be any problem for the functionality of mindthegap.