### PR TITLE
fix: Use ocischema.Manifest for plain image details

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.17.6
 	github.com/containers/image/v5 v5.21.1
 	github.com/containers/skopeo v1.8.0
-	github.com/distribution/distribution/v3 v3.0.0-20220612151901-b5e2f3f33dbc
+	github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb
 	github.com/docker/cli v20.10.17+incompatible
 	github.com/hashicorp/go-getter v1.6.2
 	github.com/mesosphere/dkp-cli-runtime/core v0.5.2

--- a/go.sum
+++ b/go.sum
@@ -402,8 +402,8 @@ github.com/dgrijalva/jwt-go v0.0.0-20170104182250-a601269ab70c/go.mod h1:E3ru+11
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/disiqueira/gotree/v3 v3.0.2/go.mod h1:ZuyjE4+mUQZlbpkI24AmruZKhg3VHEgPLDY8Qk+uUu8=
-github.com/distribution/distribution/v3 v3.0.0-20220612151901-b5e2f3f33dbc h1:sH6yEQKR8abjkiPCcE5dKUz2Hin4QWf/LB9CR0fu17A=
-github.com/distribution/distribution/v3 v3.0.0-20220612151901-b5e2f3f33dbc/go.mod h1:28YO/VJk9/64+sTGNuYaBjWxrXTPrj0C0XmgTIOjxX4=
+github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb h1:oCCuuU3kMO3sjZH/p7LamvQNW9SWoT4yQuMGcdSxGAE=
+github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb/go.mod h1:28YO/VJk9/64+sTGNuYaBjWxrXTPrj0C0XmgTIOjxX4=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v20.10.17+incompatible h1:eO2KS7ZFeov5UJeaDmIs1NFEDRf32PaqRpvoEkKBy5M=

--- a/skopeo/skopeo.go
+++ b/skopeo/skopeo.go
@@ -19,6 +19,7 @@ import (
 	"github.com/containers/skopeo/cmd/skopeo/inspect"
 	"github.com/distribution/distribution/v3"
 	"github.com/distribution/distribution/v3/manifest/manifestlist"
+	"github.com/distribution/distribution/v3/manifest/ocischema"
 	"github.com/distribution/distribution/v3/manifest/schema2"
 	"github.com/docker/cli/cli/config"
 	"k8s.io/klog/v2"
@@ -179,7 +180,7 @@ func (r *Runner) InspectManifest(
 		return ml, rawStdout, rawStderr, nil
 	}
 
-	var m schema2.Manifest
+	var m ocischema.Manifest
 	dec = json.NewDecoder(bytes.NewReader(rawStdout))
 	dec.DisallowUnknownFields()
 	if err := dec.Decode(&m); err != nil {


### PR DESCRIPTION
This follows the OCI spec better than schema2.Manifest.
