### PR TITLE
fix: Remove skopeo static builds from git-lfs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,0 @@
-skopeo/static/skopeo-windows-amd64.exe filter=lfs diff=lfs merge=lfs -text
-skopeo/static/skopeo-windows-arm64.exe filter=lfs diff=lfs merge=lfs -text
-skopeo/static/skopeo-darwin-amd64 filter=lfs diff=lfs merge=lfs -text
-skopeo/static/skopeo-darwin-arm64 filter=lfs diff=lfs merge=lfs -text
-skopeo/static/skopeo-linux-amd64 filter=lfs diff=lfs merge=lfs -text
-skopeo/static/skopeo-linux-arm64 filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/checks-macos.yml
+++ b/.github/workflows/checks-macos.yml
@@ -30,10 +30,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          lfs: true
-
-      - name: Checkout LFS objects
-        run: git lfs checkout
 
       - name: Install asdf and tools
         uses: asdf-vm/actions/install@v1

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,12 +23,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        lfs: true
-
-    - name: Checkout LFS objects
-      run: git lfs checkout
+      uses: actions/checkout@v3
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1

--- a/.github/workflows/release-main.yaml
+++ b/.github/workflows/release-main.yaml
@@ -26,11 +26,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          lfs: true
-
-      - if: ${{ steps.release-please.outputs.release_created }}
-        name: Checkout LFS objects
-        run: git lfs checkout
 
       - if: ${{ steps.release-please.outputs.release_created }}
         name: Install asdf and tools

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ dist/
 .local/
 
 *.tar.gz
+
+/skopeo/static/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -46,9 +46,12 @@ builds:
       - amd64
       - arm64
     mod_timestamp: '{{ .CommitTimestamp }}'
-    # hooks:
-    #   post: |
-    #     make IS_SNAPSHOT={{ .IsSnapshot }} GOOS={{ .Os }} GOARCH={{ .Arch }} UPX_TARGET={{ .Path }} upx
+    hooks:
+      pre:
+        - cmd: make go-generate
+          env:
+            - GOOS={{ .Os }}
+            - GOARCH={{ .Arch }}
 archives:
   - name_template: '{{ .ProjectName }}_v{{trimprefix .Version "v"}}_{{ .Os }}_{{ .Arch }}'
   # This is a hack documented in https://github.com/goreleaser/goreleaser/blob/df0216d5855e9283d2106fb5acdb0e7b528a56e8/www/docs/customization/archive.md#packaging-only-the-binaries

--- a/README.md
+++ b/README.md
@@ -126,14 +126,6 @@ or in a Kubernetes cluster.
 
 ## Building
 
-### Prerequisite: set up git lfs
-
-`mindthegap` embeds a static build of [`skopeo`](https://github.com/containers/skopeo). In order to
-make keep the repo clean, the static builds of `skopeo` are added via
-[`git lfs`](https://git-lfs.github.com/). If you haven't previously set up `git lfs` on your machine
-(don't worry, it's just a case of install `git-lfs` and running `git lfs install`), then follow the
-instructions on the `git lfs` site.
-
 ### Building the CLI
 
 Build the CLI using `make build-snapshot` that will output binary into

--- a/make/go.mk
+++ b/make/go.mk
@@ -36,7 +36,7 @@ endef
 
 .PHONY: test
 test: ## Runs go tests for all modules in repository
-test: install-tool.go.gotestsum
+test: install-tool.go.gotestsum go-generate
 ifneq ($(wildcard $(REPO_ROOT)/go.mod),)
 test: test.root
 endif

--- a/make/go.mk
+++ b/make/go.mk
@@ -121,7 +121,7 @@ go-clean.%: install-tool.golang; $(info $(M) running go clean for $* module)
 
 .PHONY: go-generate
 go-generate: ## Runs go generate
-go-generate: install-tool.mockery ; $(info $(M) running go generate)
+go-generate: install-tool.golang ; $(info $(M) running go generate)
 	go generate ./...
 
 .PHONY: go-mod-upgrade

--- a/skopeo/skopeo.go
+++ b/skopeo/skopeo.go
@@ -25,6 +25,8 @@ import (
 	"k8s.io/klog/v2"
 )
 
+//go:generate bash -ec "cd ../ && make skopeo.build"
+
 //go:embed default-policy.json
 var defaultSkopeoPolicy []byte
 

--- a/skopeo/static/skopeo-darwin-amd64
+++ b/skopeo/static/skopeo-darwin-amd64
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:82fc5abdf4298dc2ebe08050e4e26f822ad064234db5f0e5d3c36e75c801673d
-size 20226128

--- a/skopeo/static/skopeo-darwin-arm64
+++ b/skopeo/static/skopeo-darwin-arm64
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8b406d8ab9bdd9360a429a4e210bbc7295ae75330a3678f168a9156978b27b3b
-size 19966146

--- a/skopeo/static/skopeo-linux-amd64
+++ b/skopeo/static/skopeo-linux-amd64
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:295d8df078ab762d23d2c97f817c8c878f7a9e7dfe53fc3ede3ef4149e8a6852
-size 18886656

--- a/skopeo/static/skopeo-linux-arm64
+++ b/skopeo/static/skopeo-linux-arm64
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1780aaf8c3851df8d299fffc54b043c770ec1bf9aa6cad3e127281b9401376ea
-size 18153472

--- a/skopeo/static/skopeo-windows-amd64.exe
+++ b/skopeo/static/skopeo-windows-amd64.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7f6ca392b9d4ce5765d63c514351b05d6c838ed1f8f2663d1d072f2ceb6d2c38
-size 19846144

--- a/skopeo/static/skopeo-windows-arm64.exe
+++ b/skopeo/static/skopeo-windows-arm64.exe
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1529126b47d897466c6423ab532be9cd46af95c5c75680a1dab7079f742f4f3
-size 19074048


### PR DESCRIPTION
This increases build time, makes the project not go-gettable, but
saves storage and money in GitHub.
