### PR TITLE
fix!: Remove unnecessary gzip compression of bundles by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,5 +23,6 @@ dist/
 .local/
 
 *.tar.gz
+*.tar
 
 /skopeo/static/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ image registry.
 ```shell
 mindthegap create image-bundle --images-file <path/to/images.yaml> \
   --platform <platform> [--platform <platform> ...] \
-  [--output-file <path/to/output.tar.gz>]
+  [--output-file <path/to/output.tar>]
 ```
 
 See the [example images.yaml](images-example.yaml) for the structure of the
@@ -89,7 +89,7 @@ command requires `ctr` to be in the `PATH`.
 
 ```shell
 mindthegap create helm-bundle --helm-charts-file <path/to/helm-charts.yaml> \
-  [--output-file <path/to/output.tar.gz>]
+  [--output-file <path/to/output.tar>]
 ```
 
 See the [example helm-charts.yaml](helm-example.yaml) for the structure of the
@@ -102,7 +102,7 @@ the charts used locally via Helm.
 #### Serving a Helm chart bundle
 
 ```shell
-mindthegap serve helm-bundle --helm-charts-bundle <path/to/helm-charts.tar.gz> \
+mindthegap serve helm-bundle --helm-charts-bundle <path/to/helm-charts.tar> \
   [--listen-address <addr>] \
   [--list-port <port>] \
   [--tls-cert-file <path/to/cert/file> --tls-private-key-file <path/to/key/file>]

--- a/cmd/mindthegap/create/create.go
+++ b/cmd/mindthegap/create/create.go
@@ -15,7 +15,7 @@ import (
 func NewCommand(out output.Output) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "create",
-		Short: "Create an tar.gz image or helm bundle",
+		Short: "Create an image or helm bundle",
 	}
 
 	cmd.AddCommand(imagebundle.NewCommand(out))

--- a/cmd/mindthegap/create/helmbundle/helm_bundle.go
+++ b/cmd/mindthegap/create/helmbundle/helm_bundle.go
@@ -31,7 +31,7 @@ func NewCommand(out output.Output) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "helm-bundle",
-		Short: "Create a tar.gz helm bundle",
+		Short: "Create a helm bundle",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !overwrite {
 				out.StartOperation("Checking if output file already exists")
@@ -172,7 +172,7 @@ func NewCommand(out output.Output) *cobra.Command {
 		"YAML file containing configuration of Helm charts to create bundle from")
 	_ = cmd.MarkFlagRequired("helm-charts-file")
 	cmd.Flags().
-		StringVar(&outputFile, "output-file", "helm-charts.tar.gz", "Output file to write Helm charts bundle to")
+		StringVar(&outputFile, "output-file", "helm-charts.tar", "Output file to write Helm charts bundle to")
 	cmd.Flags().
 		BoolVar(&overwrite, "overwrite", false, "Overwrite Helm charts bundle file if it already exists")
 

--- a/cmd/mindthegap/create/imagebundle/image_bundle.go
+++ b/cmd/mindthegap/create/imagebundle/image_bundle.go
@@ -32,7 +32,7 @@ func NewCommand(out output.Output) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "image-bundle",
-		Short: "Create a tar.gz image bundle",
+		Short: "Create an image bundle",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if !overwrite {
 				out.StartOperation("Checking if output file already exists")
@@ -286,7 +286,7 @@ func NewCommand(out output.Output) *cobra.Command {
 		Var(newPlatformSlicesValue([]platform{{os: "linux", arch: "amd64"}}, &platforms), "platform",
 			"platforms to download images (required format: <os>/<arch>[/<variant>])")
 	cmd.Flags().
-		StringVar(&outputFile, "output-file", "images.tar.gz", "Output file to write image bundle to")
+		StringVar(&outputFile, "output-file", "images.tar", "Output file to write image bundle to")
 	cmd.Flags().
 		BoolVar(&overwrite, "overwrite", false, "Overwrite image bundle file if it already exists")
 


### PR DESCRIPTION
Data is already stored as compressed so removing the gz suffix by default. This
is a breaking change but one that will only affect users that rely on the default
output file naming, which in reality should not be anyone.
