### PR TITLE
feat: support globs for image and helm bundles

### DIFF
--- a/cmd/mindthegap/importcmd/imagebundle/image_bundle.go
+++ b/cmd/mindthegap/importcmd/imagebundle/image_bundle.go
@@ -42,6 +42,10 @@ func NewCommand(out output.Output) *cobra.Command {
 			cleaner.AddCleanupFn(func() { _ = os.RemoveAll(tempDir) })
 			out.EndOperation(true)
 
+			imageBundleFiles, err = utils.FilesWithGlobs(imageBundleFiles)
+			if err != nil {
+				return err
+			}
 			cfg, _, err := utils.ExtractBundles(tempDir, out, imageBundleFiles...)
 			if err != nil {
 				return err
@@ -119,8 +123,8 @@ func NewCommand(out output.Output) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().
-		StringSliceVar(&imageBundleFiles, "image-bundle", nil, "Tarball containing list of images to import")
+	cmd.Flags().StringSliceVar(&imageBundleFiles, "image-bundle", nil,
+		"Tarball containing list of images to import. Can also be a glob pattern.")
 	_ = cmd.MarkFlagRequired("image-bundle")
 	cmd.Flags().StringVar(&containerdNamespace, "containerd-namespace", "k8s.io",
 		"Containerd namespace to import images into")

--- a/cmd/mindthegap/push/helmbundle/helm_bundle.go
+++ b/cmd/mindthegap/push/helmbundle/helm_bundle.go
@@ -45,6 +45,10 @@ func NewCommand(out output.Output) *cobra.Command {
 			cleaner.AddCleanupFn(func() { _ = os.RemoveAll(tempDir) })
 			out.EndOperation(true)
 
+			helmBundleFiles, err = utils.FilesWithGlobs(helmBundleFiles)
+			if err != nil {
+				return err
+			}
 			_, cfg, err := utils.ExtractBundles(tempDir, out, helmBundleFiles...)
 			if err != nil {
 				return err
@@ -116,8 +120,8 @@ func NewCommand(out output.Output) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().
-		StringSliceVar(&helmBundleFiles, "helm-bundle", nil, "Tarball containing list of Helm charts to push")
+	cmd.Flags().StringSliceVar(&helmBundleFiles, "helm-bundle", nil,
+		"Tarball containing list of Helm charts to push. Can also be a glob pattern.")
 	_ = cmd.MarkFlagRequired("helm-bundle")
 	cmd.Flags().StringVar(&destRepository, "to-repository", "", "Repository to push images to")
 	_ = cmd.MarkFlagRequired("to-repository")

--- a/cmd/mindthegap/push/imagebundle/image_bundle.go
+++ b/cmd/mindthegap/push/imagebundle/image_bundle.go
@@ -46,6 +46,10 @@ func NewCommand(out output.Output) *cobra.Command {
 			cleaner.AddCleanupFn(func() { _ = os.RemoveAll(tempDir) })
 			out.EndOperation(true)
 
+			imageBundleFiles, err = utils.FilesWithGlobs(imageBundleFiles)
+			if err != nil {
+				return err
+			}
 			cfg, _, err := utils.ExtractBundles(tempDir, out, imageBundleFiles...)
 			if err != nil {
 				return err
@@ -117,8 +121,8 @@ func NewCommand(out output.Output) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().
-		StringSliceVar(&imageBundleFiles, "image-bundle", nil, "Tarball containing list of images to push")
+	cmd.Flags().StringSliceVar(&imageBundleFiles, "image-bundle", nil,
+		"Tarball containing list of images to push. Can also be a glob pattern.")
 	_ = cmd.MarkFlagRequired("image-bundle")
 	cmd.Flags().StringVar(&destRegistry, "to-registry", "", "Registry to push images to")
 	_ = cmd.MarkFlagRequired("to-registry")

--- a/cmd/mindthegap/serve/helmbundle/helm_bundle.go
+++ b/cmd/mindthegap/serve/helmbundle/helm_bundle.go
@@ -43,6 +43,10 @@ func NewCommand(out output.Output) *cobra.Command {
 
 			out.EndOperation(true)
 
+			helmBundleFiles, err = utils.FilesWithGlobs(helmBundleFiles)
+			if err != nil {
+				return err
+			}
 			_, cfg, err := utils.ExtractBundles(tempDir, out, helmBundleFiles...)
 			if err != nil {
 				return err
@@ -79,8 +83,8 @@ func NewCommand(out output.Output) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().
-		StringSliceVar(&helmBundleFiles, "helm-bundle", nil, "Tarball of Helm charts to serve")
+	cmd.Flags().StringSliceVar(&helmBundleFiles, "helm-bundle", nil,
+		"Tarball of Helm charts to serve. Can also be a glob pattern.")
 	_ = cmd.MarkFlagRequired("helm-bundle")
 	cmd.Flags().StringVar(&listenAddress, "listen-address", "localhost", "Address to listen on")
 	cmd.Flags().

--- a/cmd/mindthegap/serve/imagebundle/image_bundle.go
+++ b/cmd/mindthegap/serve/imagebundle/image_bundle.go
@@ -43,6 +43,10 @@ func NewCommand(out output.Output) *cobra.Command {
 
 			out.EndOperation(true)
 
+			imageBundleFiles, err = utils.FilesWithGlobs(imageBundleFiles)
+			if err != nil {
+				return err
+			}
 			cfg, _, err := utils.ExtractBundles(tempDir, out, imageBundleFiles...)
 			if err != nil {
 				return err
@@ -79,8 +83,8 @@ func NewCommand(out output.Output) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().
-		StringSliceVar(&imageBundleFiles, "images-bundle", nil, "Tarball of images to serve")
+	cmd.Flags().StringSliceVar(&imageBundleFiles, "images-bundle", nil,
+		"Tarball of images to serve. Can also be a glob pattern.")
 	_ = cmd.MarkFlagRequired("images-bundle")
 	cmd.Flags().StringVar(&listenAddress, "listen-address", "localhost", "Address to listen on")
 	cmd.Flags().

--- a/cmd/mindthegap/utils/glob.go
+++ b/cmd/mindthegap/utils/glob.go
@@ -1,0 +1,27 @@
+// Copyright 2021 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// FilesWithGlobs expects a list of files and/or globs, and returns a new list of files.
+// Returns an error if in does not match any files on the disk.
+func FilesWithGlobs(in []string) ([]string, error) {
+	var out []string
+	for _, file := range in {
+		matches, err := filepath.Glob(file)
+		if err != nil {
+			return nil, fmt.Errorf("error finding matching files for %q: %w", file, err)
+		}
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("did find any matching files for %q", file)
+		}
+		out = append(out, matches...)
+	}
+
+	return out, nil
+}

--- a/cmd/mindthegap/utils/glob_test.go
+++ b/cmd/mindthegap/utils/glob_test.go
@@ -1,0 +1,104 @@
+// Copyright 2021 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilesWithGlobs(t *testing.T) {
+	t.Parallel()
+
+	// filepath.Glob expects the files to exist
+	testFiles, createdFiles := tempFiles(t)
+	testGlobs, createdGlobFiles := tempGlobs(t)
+
+	//nolint:gocritic // want to a append to a new slice, its fine in tests
+	combinedTestFiles := append(testFiles, testGlobs...)
+	//nolint:gocritic // want to a append to a new slice, its fine in tests
+	combinedCreatedFiles := append(createdFiles, createdGlobFiles...)
+
+	tests := []struct {
+		name           string
+		in             []string
+		expectedOutput []string
+		wantErr        error
+	}{
+		{
+			name:    "error: file does not exist",
+			in:      []string{"doesnotexist.tar"},
+			wantErr: fmt.Errorf("did find any matching files for \"doesnotexist.tar\""),
+		},
+		{
+			name:           "all files",
+			in:             testFiles,
+			expectedOutput: createdFiles,
+		},
+		{
+			name:           "all globs",
+			in:             testGlobs,
+			expectedOutput: createdGlobFiles,
+		},
+		{
+			name:           "files and globs",
+			in:             combinedTestFiles,
+			expectedOutput: combinedCreatedFiles,
+		},
+	}
+	for ti := range tests {
+		tt := tests[ti]
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			out, err := FilesWithGlobs(tt.in)
+			require.Equal(t, tt.wantErr, err)
+			require.Equal(t, tt.expectedOutput, out)
+		})
+	}
+}
+
+//nolint:gocritic // no need for named parameters
+func tempGlobs(t *testing.T) ([]string, []string) {
+	t.Helper()
+	tempDir1 := t.TempDir()
+	tempDir2 := t.TempDir()
+	globs := []string{
+		fmt.Sprintf("%s/*.tar", tempDir1),
+		fmt.Sprintf("%s/*.tar", tempDir2),
+	}
+
+	filesToCreate := []string{
+		filepath.Join(tempDir1, "images1.tar"),
+		filepath.Join(tempDir1, "images2.tar"),
+		filepath.Join(tempDir2, "images1.tar"),
+	}
+	for _, createFile := range filesToCreate {
+		_, err := os.Create(createFile)
+		require.NoError(t, err)
+	}
+
+	return globs, filesToCreate
+}
+
+//nolint:gocritic // no need for named parameters
+func tempFiles(t *testing.T) ([]string, []string) {
+	t.Helper()
+	tempDir1 := t.TempDir()
+	tempDir2 := t.TempDir()
+	filesToCreate := []string{
+		filepath.Join(tempDir1, "images1.tar"),
+		filepath.Join(tempDir1, "images2.tar"),
+		filepath.Join(tempDir2, "images1.tar"),
+	}
+	for _, createFile := range filesToCreate {
+		_, err := os.Create(createFile)
+		require.NoError(t, err)
+	}
+
+	return filesToCreate, filesToCreate
+}


### PR DESCRIPTION
Handles file globs for `--image-bundle` and `--helm-bundle`.
This also will fail fast if the file does not exist.

```
➜  mindthegap git:(dkoshkin/globs) ✗ dist/mindthegap_darwin_amd64_v1/mindthegap push image-bundle --image-bundle="glob-test/*.tar" --image-bundle=glob-test-2/dkoshkin-images1.tar --to-registry=127.0.0.1:5000 --to-registry-insecure-skip-tls-verify=true
 ✓ Creating temporary directory
 ✓ Unarchiving image bundle "glob-test-2/dkoshkin-images1.tar"
 ✓ Parsing image bundle config
 ✓ Unarchiving image bundle "glob-test/dkoshkin-images1.tar"
 ✓ Parsing image bundle config
 ✓ Unarchiving image bundle "glob-test/dkoshkin-images2.tar"
 ✓ Parsing image bundle config
 ✓ Starting temporary Docker registry
 ✓ Copying docker.io/library/busybox:latest (from bundle) to 127.0.0.1:5000/library/busybox:latest
 ✓ Copying docker.io/library/nginx:1.21.5 (from bundle) to 127.0.0.1:5000/library/nginx:1.21.5
 ✓ Copying docker.io/library/registry:2 (from bundle) to 127.0.0.1:5000/library/registry:2
➜  mindthegap git:(dkoshkin/globs) ✗ dist/mindthegap_darwin_amd64_v1/mindthegap push image-bundle --image-bundle="glob-test/*.tar" --image-bundle=glob-test-2/dkoshkin-images2.tar --to-registry=127.0.0.1:5000 --to-registry-insecure-skip-tls-verify=true
 ✓ Creating temporary directory
did find any matching files for "glob-test-2/dkoshkin-images2.tar"
```