### PR TITLE
test: Add e2e test for import image-bundle 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,11 +12,13 @@ require (
 	github.com/containers/skopeo v1.9.2
 	github.com/distribution/distribution/v3 v3.0.0-20220725133111-4bf3547399eb
 	github.com/docker/cli v20.10.18+incompatible
+	github.com/docker/docker v20.10.18+incompatible
 	github.com/hashicorp/go-getter v1.6.2
 	github.com/mesosphere/dkp-cli-runtime/core v0.6.0
 	github.com/mholt/archiver/v3 v3.5.1
 	github.com/onsi/ginkgo/v2 v2.1.6
 	github.com/onsi/gomega v1.20.2
+	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.5.0
@@ -39,6 +41,7 @@ require (
 	github.com/Masterminds/semver/v3 v3.1.1 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.2 // indirect
 	github.com/Masterminds/squirrel v1.5.3 // indirect
+	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/andybalholm/brotli v1.0.4 // indirect
@@ -64,7 +67,6 @@ require (
 	github.com/cyphar/filepath-securejoin v0.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
-	github.com/docker/docker v20.10.17+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.6.4 // indirect
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c // indirect
@@ -136,7 +138,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/nwaples/rardecode v1.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
-	github.com/opencontainers/image-spec v1.0.3-0.20220114050600-8b9d41f48198 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/Masterminds/sprig/v3 v3.2.2/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFP
 github.com/Masterminds/squirrel v1.5.3 h1:YPpoceAcxuzIljlr5iWpNKaql7hLeG1KLSrhvdHpkZc=
 github.com/Masterminds/squirrel v1.5.3/go.mod h1:NNaOrjSoIDfDA40n7sr2tPNZRfjzjA400rg+riTZj10=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
+github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/hcsshim v0.9.3 h1:k371PzBuRrz2b+ebGuI2nVgVhgsVX60jMfSw80NECxo=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
@@ -257,8 +258,8 @@ github.com/docker/cli v20.10.18+incompatible h1:f/GQLsVpo10VvToRay2IraVA1wHz9Kkt
 github.com/docker/cli v20.10.18+incompatible/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/distribution v2.8.1+incompatible h1:Q50tZOPR6T/hjNsyc9g8/syEs6bk8XXApsHjKukMl68=
 github.com/docker/distribution v2.8.1+incompatible/go.mod h1:J2gT2udsDAN96Uj4KfcMRqY0/ypR+oyYUYmja8H+y+w=
-github.com/docker/docker v20.10.17+incompatible h1:JYCuMrWaVNophQTOrMMoSwudOVEfcegoZZrleKc1xwE=
-github.com/docker/docker v20.10.17+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
+github.com/docker/docker v20.10.18+incompatible h1:SN84VYXTBNGn92T/QwIRPlum9zfemfitN7pbsp26WSc=
+github.com/docker/docker v20.10.18+incompatible/go.mod h1:eEKB0N0r5NX/I1kEveEz05bcu8tLC/8azJZsviup8Sk=
 github.com/docker/docker-credential-helpers v0.6.4 h1:axCks+yV+2MR3/kZhAmy07yC56WZ2Pwu/fKWtKuZB0o=
 github.com/docker/docker-credential-helpers v0.6.4/go.mod h1:ofX3UI0Gz1TteYBjtgs07O36Pyasyp66D2uKT7H8W1c=
 github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKohAFqRJQ=

--- a/make/go.mk
+++ b/make/go.mk
@@ -79,6 +79,7 @@ E2E_FLAKE_ATTEMPTS ?= 1
 e2e-test: ## Runs e2e tests
 e2e-test: install-tool.golang install-tool.ginkgo skopeo.build
 	$(info $(M) running e2e tests$(if $(E2E_LABEL), labelled "$(E2E_LABEL)")$(if $(E2E_FOCUS), matching "$(E2E_FOCUS)"))
+	GOOS=linux $(MAKE) build-snapshot
 	ginkgo run \
 		--r \
 		--race \

--- a/test/e2e/helmbundle/create_bundle_test.go
+++ b/test/e2e/helmbundle/create_bundle_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e
-// +build e2e
 
 package helmbundle_test
 

--- a/test/e2e/helmbundle/helm_bundle_suite_test.go
+++ b/test/e2e/helmbundle/helm_bundle_suite_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e
-// +build e2e
 
 package helmbundle_test
 

--- a/test/e2e/helmbundle/helpers/helpers.go
+++ b/test/e2e/helmbundle/helpers/helpers.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e
-// +build e2e
 
 package helpers
 

--- a/test/e2e/helmbundle/push_bundle_test.go
+++ b/test/e2e/helmbundle/push_bundle_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e
-// +build e2e
 
 package helmbundle_test
 

--- a/test/e2e/helmbundle/serve_bundle_test.go
+++ b/test/e2e/helmbundle/serve_bundle_test.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e
-// +build e2e
 
 package helmbundle_test
 

--- a/test/e2e/imagebundle/helpers/docker.go
+++ b/test/e2e/imagebundle/helpers/docker.go
@@ -1,0 +1,159 @@
+// Copyright 2021 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build e2e
+
+package helpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/network"
+	"github.com/docker/docker/client"
+	"github.com/docker/docker/pkg/stdcopy"
+	specs "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+var ErrDockerDaemonNotAccessible = errors.New("Docker daemon is not accessible")
+
+type Docker struct {
+	cl *client.Client
+}
+
+func NewDockerClient() (*Docker, error) {
+	cl, err := client.NewClientWithOpts(client.FromEnv)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = cl.Info(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrDockerDaemonNotAccessible, err)
+	}
+
+	return &Docker{cl: cl}, nil
+}
+
+func (d *Docker) PullImage(ctx context.Context, image string) error {
+	_, _, err := d.cl.ImageInspectWithRaw(ctx, image)
+	if err == nil {
+		return nil
+	}
+	if !client.IsErrNotFound(err) {
+		return fmt.Errorf("failed to inspect image %q: %w", image, err)
+	}
+
+	r, err := d.cl.ImagePull(ctx, image, types.ImagePullOptions{})
+	defer r.Close()
+	if err != nil {
+		return fmt.Errorf("failed to pull image %q: %w", image, err)
+	}
+	_, err = io.Copy(io.Discard, r)
+	if err != nil {
+		return fmt.Errorf("failed to swallow pull image output: %w", err)
+	}
+
+	return nil
+}
+
+func (d *Docker) StartContainer(ctx context.Context, cfg container.Config) (*Container, error) {
+	if err := d.PullImage(ctx, cfg.Image); err != nil {
+		return nil, err
+	}
+
+	container, err := d.cl.ContainerCreate(
+		ctx,
+		&cfg,
+		&container.HostConfig{},
+		&network.NetworkingConfig{},
+		&specs.Platform{},
+		"",
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := d.cl.ContainerStart(ctx, container.ID, types.ContainerStartOptions{}); err != nil {
+		_ = d.cl.ContainerRemove(
+			ctx,
+			container.ID,
+			types.ContainerRemoveOptions{Force: true, RemoveVolumes: true},
+		)
+
+		return nil, err
+	}
+
+	return &Container{
+		id: container.ID,
+		d:  d,
+	}, nil
+}
+
+func (d *Docker) Close() error {
+	return d.cl.Close()
+}
+
+type Container struct {
+	id string
+	d  *Docker
+}
+
+func (c *Container) Stop(ctx context.Context) error {
+	return c.d.cl.ContainerRemove(
+		ctx,
+		c.id,
+		types.ContainerRemoveOptions{Force: true, RemoveVolumes: true},
+	)
+}
+
+func (c *Container) CopyTo(ctx context.Context, dest string, src io.Reader) error {
+	return c.d.cl.CopyToContainer(ctx, c.id, dest, src, types.CopyToContainerOptions{})
+}
+
+func (c *Container) Exec(
+	ctx context.Context,
+	stdout, stderr io.Writer,
+	cmd ...string,
+) (int, error) {
+	exec, err := c.d.cl.ContainerExecCreate(
+		ctx,
+		c.id,
+		types.ExecConfig{
+			Cmd:          cmd,
+			AttachStdout: true,
+			AttachStderr: true,
+		},
+	)
+	if err != nil {
+		return -1, fmt.Errorf("failed to create exec in container: %w", err)
+	}
+	resp, err := c.d.cl.ContainerExecAttach(ctx, exec.ID, types.ExecStartCheck{})
+	if err != nil {
+		return -1, fmt.Errorf("failed to attach exec in container: %w", err)
+	}
+	defer resp.Close()
+	errCh := make(chan error)
+	go func() {
+		_, err := stdcopy.StdCopy(stdout, stderr, resp.Reader)
+		if err != nil {
+			errCh <- fmt.Errorf("failed to copy exec streams: %w", err)
+		}
+		close(errCh)
+	}()
+	if err := c.d.cl.ContainerExecStart(ctx, exec.ID, types.ExecStartCheck{}); err != nil {
+		return -1, fmt.Errorf("failed to start exec in container: %w", err)
+	}
+	if err := <-errCh; err != nil {
+		return -1, fmt.Errorf("failed to read exec streams: %w", err)
+	}
+	execInspect, err := c.d.cl.ContainerExecInspect(ctx, exec.ID)
+	if err != nil {
+		return -1, fmt.Errorf("failed to inspect exec in container: %w", err)
+	}
+	return execInspect.ExitCode, nil
+}

--- a/test/e2e/imagebundle/helpers/helpers.go
+++ b/test/e2e/imagebundle/helpers/helpers.go
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //go:build e2e
-// +build e2e
 
 package helpers
 

--- a/test/e2e/imagebundle/imagebundle_suite_test.go
+++ b/test/e2e/imagebundle/imagebundle_suite_test.go
@@ -1,6 +1,8 @@
 // Copyright 2021 D2iQ, Inc. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+//go:build e2e
+
 package imagebundle_test
 
 import (

--- a/test/e2e/imagebundle/import_bundle_test.go
+++ b/test/e2e/imagebundle/import_bundle_test.go
@@ -1,0 +1,135 @@
+// Copyright 2021 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build e2e
+
+package imagebundle_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/docker/docker/api/types/container"
+	"github.com/docker/docker/api/types/strslice"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
+
+	"github.com/mesosphere/mindthegap/archive"
+	importimagebundle "github.com/mesosphere/mindthegap/cmd/mindthegap/importcmd/imagebundle"
+	"github.com/mesosphere/mindthegap/cmd/mindthegap/utils"
+	"github.com/mesosphere/mindthegap/test/e2e/imagebundle/helpers"
+)
+
+var _ = Describe("Import Bundle", func() {
+	var (
+		bundleFile string
+		cmd        *cobra.Command
+	)
+
+	BeforeEach(func() {
+		tmpDir := GinkgoT().TempDir()
+
+		bundleFile = filepath.Join(tmpDir, "image-bundle.tar")
+
+		cmd = helpers.NewCommand(GinkgoT(), importimagebundle.NewCommand)
+	})
+
+	It("Success", func() {
+		helpers.CreateBundle(
+			GinkgoT(),
+			bundleFile,
+			filepath.Join("testdata", "import-bundle.yaml"),
+		)
+
+		copyFileTempDir := GinkgoT().TempDir()
+		Expect(
+			os.Rename(bundleFile, filepath.Join(copyFileTempDir, filepath.Base(bundleFile))),
+		).To(Succeed())
+		Expect(
+			utils.CopyFile(
+				filepath.Join(
+					"..",
+					"..",
+					"..",
+					"dist",
+					fmt.Sprintf("mindthegap_linux_%s_v1", runtime.GOARCH),
+					"mindthegap",
+				),
+				filepath.Join(copyFileTempDir, "mindthegap"),
+			),
+		).To(Succeed())
+
+		tarToCopy := filepath.Join(copyFileTempDir, "copy.tar")
+		Expect(archive.ArchiveDirectory(copyFileTempDir, tarToCopy)).To(Succeed())
+		f, err := os.Open(tarToCopy)
+		Expect(err).NotTo(HaveOccurred())
+
+		dc, err := helpers.NewDockerClient()
+		if errors.Is(err, helpers.ErrDockerDaemonNotAccessible) {
+			Skip(fmt.Sprintf("Docker daemon is not accessible: %v", err))
+		}
+		DeferCleanup(dc.Close)
+
+		ctx := context.Background()
+
+		c, err := dc.StartContainer(
+			ctx,
+			container.Config{
+				Image:      "mesosphere/kind-node:v1.25.0",
+				Entrypoint: strslice.StrSlice{"containerd"},
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(c.Stop, ctx)
+
+		Expect(c.CopyTo(ctx, "/tmp", f)).To(Succeed())
+
+		exitCode, err := c.Exec(
+			ctx,
+			GinkgoWriter,
+			GinkgoWriter,
+			"/tmp/mindthegap",
+			"import",
+			"image-bundle",
+			"--image-bundle",
+			filepath.Join("/tmp", filepath.Base(bundleFile)),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exitCode).To(Equal(0))
+
+		var outBuf, errBuf bytes.Buffer
+		exitCode, err = c.Exec(
+			ctx,
+			&outBuf,
+			&errBuf,
+			"crictl",
+			"inspecti",
+			"-q",
+			"-o", "go-template",
+			"--template", "{{.status.id}}",
+			"mesosphere/kube-apiserver:v1.24.4_fips.0",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(exitCode).To(Equal(0))
+
+		Expect(strings.TrimSpace(outBuf.String())).
+			To(Equal("sha256:b7c51f9294349f26b8ab08272253c70e94cd1a06ef938875a12f8f7f4753c4ec"))
+	})
+
+	It("Bundle does not exist", func() {
+		cmd.SetArgs([]string{
+			"--image-bundle", bundleFile,
+		})
+
+		Expect(
+			cmd.Execute(),
+		).To(MatchError(fmt.Sprintf("did find any matching files for %q", bundleFile)))
+	})
+})

--- a/test/e2e/imagebundle/testdata/import-bundle.yaml
+++ b/test/e2e/imagebundle/testdata/import-bundle.yaml
@@ -1,0 +1,7 @@
+# Copyright 2021 D2iQ, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+docker.io:
+  images:
+    mesosphere/kube-apiserver:
+      - v1.24.4_fips.0


### PR DESCRIPTION
This test uses Docker to spin up a container based on a KinD image which contains containerd. `mindthegap` binary and a created image bundle are copied to the container, `import image-bundle` is run, and then the image ID is retrieved from containerd via `crictl`. A known image ID is used to ensure that it does not change and to prevent regressions.

Depends on #191.