### PR TITLE
fix: Properly handle friendly image names

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ images config file. You can also provide the images file in a simple file with
 an image per line, e.g.
 
 ```plain
-docker.io/library/nginx:1.21.5
+nginx:1.21.5
 test.registry2.io/test-image6:atag
 ```
 

--- a/config/images_config.go
+++ b/config/images_config.go
@@ -162,7 +162,7 @@ func ParseImagesConfigFile(configFile string) (ImagesConfig, error) {
 		if trimmedLine == "" || strings.HasPrefix(trimmedLine, "#") {
 			continue
 		}
-		named, nameErr := reference.ParseNamed(trimmedLine)
+		named, nameErr := reference.ParseNormalizedNamed(trimmedLine)
 		if nameErr != nil {
 			return ImagesConfig{}, fmt.Errorf("failed to parse config file: %w", nameErr)
 		}

--- a/config/images_config_test.go
+++ b/config/images_config_test.go
@@ -114,6 +114,11 @@ func TestParseImagesFile(t *testing.T) {
 					"test-image5": {"tag32", "tag42", "tag52"},
 					"test-image6": {"tag63", "tag73", "tag83"},
 				},
+			}, "docker.io": RegistrySyncConfig{
+				Images: map[string][]string{
+					"plain/image":    {"tag"},
+					"library/image2": {"tag2"},
+				},
 			},
 		},
 	}}

--- a/config/testdata/images/multiple_registries_with_multiple_images_with_multiple_tags_in_plain_text_file.txt
+++ b/config/testdata/images/multiple_registries_with_multiple_images_with_multiple_tags_in_plain_text_file.txt
@@ -1,5 +1,6 @@
 #  Copyright 2021 D2iQ, Inc. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
+
 test.registry.io/test-image:tag1
 test.registry.io/test-image:tag3
 test.registry.io/test-image:tag2
@@ -19,3 +20,6 @@ test.registry2.io/test-image5:tag52
 test.registry2.io/test-image6:tag63
 test.registry2.io/test-image6:tag73
 test.registry2.io/test-image6:tag83
+
+plain/image:tag
+image2:tag2

--- a/test/e2e/imagebundle/import_bundle_test.go
+++ b/test/e2e/imagebundle/import_bundle_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Import Bundle", func() {
 		helpers.CreateBundle(
 			GinkgoT(),
 			bundleFile,
-			filepath.Join("testdata", "import-bundle.yaml"),
+			filepath.Join("testdata", "import-bundle.txt"),
 		)
 
 		copyFileTempDir := GinkgoT().TempDir()

--- a/test/e2e/imagebundle/testdata/import-bundle.txt
+++ b/test/e2e/imagebundle/testdata/import-bundle.txt
@@ -1,7 +1,4 @@
 # Copyright 2021 D2iQ, Inc. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-docker.io:
-  images:
-    mesosphere/kube-apiserver:
-      - v1.24.4_fips.0
+mesosphere/kube-apiserver:v1.24.4_fips.0


### PR DESCRIPTION
Previously a user would have to specify a canonical image ref for images
even on Docker Hub. This fixes that by allowing user-friendly names that
users are likely more used to.
