### PR TITLE
feat: Add Docker image

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,5 @@
 use asdf
 PATH_add .local/bin
+PATH_add skopeo/static
 
 dotenv_if_exists .envrc.local

--- a/.github/workflows/checks-macos.yml
+++ b/.github/workflows/checks-macos.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build
         run: make release
         env:
-          GORELEASER_FLAGS: --skip-publish --skip-validate
+          GORELEASER_FLAGS: --skip-publish --skip-validate --skip-docker
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run binary

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -63,6 +63,51 @@ archives:
         format: zip
     builds:
       - mindthegap
+dockers:
+  - image_templates:
+      # Specify the image tag including `-amd64` suffix if the build is not a snapshot build or is not being built on
+      # arm64 machine. This allows for using the snapshot image build without the archtecture specific suffix
+      # consistently on local machines, i.e. can always use `mesosphere/mindthegap:v<VERSION>` on the machine the snapshot
+      # is built on.
+      #
+      # For a release build the `-amd64` suffix will always be included and the `docker_manifests` specification below
+      # will create the final multiplatform manifest to be pushed to the registry.
+      - 'mesosphere/mindthegap:v{{trimprefix .Version "v"}}{{ if or (not .IsSnapshot) (not (eq .Runtime.Goarch "amd64")) }}-amd64{{ end }}'
+    use: buildx
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title=mindthegap"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - image_templates:
+      # Specify the image tag including `-amd64v8` suffix if the build is not a snapshot build or is not being built on
+      # arm64 machine. This allows for using the snapshot image build without the archtecture specific suffix
+      # consistently on local machines, i.e. can always use `mesosphere/mindthegap:v<VERSION>` on the machine the snapshot
+      # is built on.
+      #
+      # For a release build the `-amd64v8` suffix will always be included and the `docker_manifests` specification below
+      # will create the final multiplatform manifest to be pushed to the registry.
+    - 'mesosphere/mindthegap:v{{trimprefix .Version "v"}}{{ if or (not .IsSnapshot) (not (eq .Runtime.Goarch "arm64")) }}-arm64v8{{ end }}'
+    use: buildx
+    goarch: arm64
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title=mindthegap"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+      - "--label=org.opencontainers.image.source={{.GitURL}}"
+docker_manifests:
+  - name_template: mesosphere/mindthegap:v{{trimprefix .Version "v"}}
+    image_templates:
+    - mesosphere/mindthegap:v{{trimprefix .Version "v"}}-amd64
+    - mesosphere/mindthegap:v{{trimprefix .Version "v"}}-arm64v8
 checksum:
   name_template: 'checksums.txt'
 snapshot:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,6 +1,7 @@
+gcloud 402.0.0
+ginkgo 2.1.6
 golangci-lint 1.49.0
-goreleaser 1.11.2
+goreleaser 1.11.3
 golang 1.19.1
 helm 3.9.4
 pre-commit 2.20.0
-ginkgo 2.1.6

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Copyright 2022 D2iQ, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# syntax=docker/dockerfile:1
+
+# Use distroless/static:nonroot image for a base.
+FROM --platform=linux/amd64 gcr.io/distroless/static@sha256:d11899d4ea81ceaab422afb0af9b446bb560411b9cec4664af4f913ef85f0b62 as linux-amd64
+FROM --platform=linux/arm64 gcr.io/distroless/static@sha256:690d14f648e06c53ec52a477de11f37028b764cffd18123f08bcd4179ca75a9f as linux-arm64
+
+FROM --platform=linux/${TARGETARCH} linux-${TARGETARCH}
+
+# Run as nonroot user using numeric ID for compatibllity.
+USER 65532
+
+COPY mindthegap /usr/local/bin/mindthegap
+
+ENTRYPOINT ["/usr/local/bin/mindthegap"]

--- a/make/docker.mk
+++ b/make/docker.mk
@@ -8,3 +8,12 @@ ifdef DOCKER_PASSWORD
 	echo -n $(DOCKER_PASSWORD) | docker login -u $(DOCKER_USERNAME) --password-stdin
 endif
 endif
+
+.PHONY: update-distroless-base-image
+update-distroless-base-image: install-tool.gcloud install-tool.gojq skopeo.build; $(info $(M) updating distroless base image)
+	LATEST_DISTROLESS_NONROOT_DIGEST="$$(gcloud container images list-tags gcr.io/distroless/static --format=json | gojq -r '.[] | select(.tags | index("nonroot")) | .digest')"; \
+	DISTROLESS_AMD64_DIGEST="$$(skopeo inspect --raw docker://gcr.io/distroless/static@$${LATEST_DISTROLESS_NONROOT_DIGEST} | gojq -r '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "amd64").digest')"; \
+	DISTROLESS_ARM64_DIGEST="$$(skopeo inspect --raw docker://gcr.io/distroless/static@$${LATEST_DISTROLESS_NONROOT_DIGEST} | gojq -r '.manifests[] | select(.platform.os == "linux" and .platform.architecture == "arm64").digest')"; \
+	sed -i -e "s|^\(FROM --platform=linux/amd64 \).\+$$|\1gcr.io/distroless/static@$${DISTROLESS_AMD64_DIGEST} as linux-amd64|" \
+	       -e "s|^\(FROM --platform=linux/arm64 \).\+$$|\1gcr.io/distroless/static@$${DISTROLESS_ARM64_DIGEST} as linux-arm64|" \
+	       Dockerfile

--- a/make/skopeo.mk
+++ b/make/skopeo.mk
@@ -11,6 +11,8 @@ ensure-static-skopeo:
 .PHONY: skopeo.build
 skopeo.build: ## Builds the skopeo static binary
 skopeo.build: skopeo/static/skopeo-$(GOOS)-$(GOARCH)$(if $(filter $(GOOS),windows),.exe)
+	ln -sf skopeo-$(GOOS)-$(GOARCH)$(if $(filter $(GOOS),windows),.exe) \
+	       skopeo/static/skopeo$(if $(filter $(GOOS),windows),.exe)
 
 .PHONY: skopeo.build.all
 skopeo.build.all:


### PR DESCRIPTION
This enables either using mindthegap without downloading the binary, or to build static registry images and serve inside the Kubernetes cluster.
