### PR TITLE
fix: Correctly identify ECR registries

### DIFF
--- a/docker/ecr/registry.go
+++ b/docker/ecr/registry.go
@@ -4,16 +4,13 @@
 package ecr
 
 import (
-	"net/url"
 	"regexp"
 )
 
-var ecrRegistryRegexp = regexp.MustCompile(`\.dkr\.ecr\.[^.]+\.amazonaws\.com$`)
+var ecrRegistryRegexp = regexp.MustCompile(
+	`^(?:https://)?[a-zA-Z0-9]+\.dkr\.ecr\.[^.]+\.amazonaws\.com/?`,
+)
 
 func IsECRRegistry(registryAddress string) bool {
-	u, err := url.Parse(registryAddress)
-	if err != nil {
-		return false
-	}
-	return ecrRegistryRegexp.MatchString(u.Hostname())
+	return ecrRegistryRegexp.MatchString(registryAddress)
 }

--- a/docker/ecr/registry_test.go
+++ b/docker/ecr/registry_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package ecr
+
+import "testing"
+
+func TestIsECRRegistry(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name            string
+		registryAddress string
+		want            bool
+	}{{
+		name:            "ECR",
+		registryAddress: "123456789.dkr.ecr.us-east-1.amazonaws.com",
+		want:            true,
+	}, {
+		name:            "ECR with https protocol",
+		registryAddress: "https://123456789.dkr.ecr.us-east-1.amazonaws.com",
+		want:            true,
+	}, {
+		name:            "ECR with http protocol",
+		registryAddress: "http://123456789.dkr.ecr.us-east-1.amazonaws.com",
+		want:            false,
+	}, {
+		name:            "non-ECR",
+		registryAddress: "gcr.io",
+		want:            false,
+	}, {
+		name:            "non-ECR with https protocol",
+		registryAddress: "https://gcr.io",
+		want:            false,
+	}, {
+		name:            "non-ECR with http protocol",
+		registryAddress: "http://gcr.io",
+		want:            false,
+	}}
+	for _, tt := range tests {
+		tt := tt // Capture range variable.
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsECRRegistry(tt.registryAddress); got != tt.want {
+				t.Errorf("IsECRRegistry() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously this was failing because `url.Parse` does not parse bare
hostnames into a valid URL. Using a regexp on the whole registry
address fixes this.
