### PR TITLE
fix: Ensure docker daemon skopeo logging is output on error

### DIFF
--- a/cmd/mindthegap/create/imagebundle/image_bundle.go
+++ b/cmd/mindthegap/create/imagebundle/image_bundle.go
@@ -155,6 +155,8 @@ func NewCommand(out output.Output) *cobra.Command {
 								context.Background(),
 								fmt.Sprintf("%s%s", srcSkopeoScheme, srcImageName),
 							)
+							skopeoStdout = append(skopeoStdout, skopeoDaemonStdout...)
+							skopeoStderr = append(skopeoStderr, skopeoDaemonStderr...)
 							if err != nil {
 								out.EndOperation(false)
 								out.Infof("---skopeo stdout---:\n%s", skopeoStdout)
@@ -162,8 +164,6 @@ func NewCommand(out output.Output) *cobra.Command {
 								return err
 							}
 							srcImageManifestList = srcDaemonImageManifestList
-							skopeoStdout = append(skopeoStdout, skopeoDaemonStdout...)
-							skopeoStderr = append(skopeoStderr, skopeoDaemonStderr...)
 						}
 						out.V(4).Infof("---skopeo stdout---:\n%s", skopeoStdout)
 						out.V(4).Infof("---skopeo stderr---:\n%s", skopeoStderr)


### PR DESCRIPTION
Previously only the registry inspect output was emitted, but to
diagnose certain issues the connection to docker dameon should
also be included in error logs.
