### PR TITLE
ci: skip upx on release

### DIFF
--- a/.github/workflows/release-main.yaml
+++ b/.github/workflows/release-main.yaml
@@ -41,3 +41,4 @@ jobs:
         run: make release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_UPX: true


### PR DESCRIPTION
Skip running upx on released binaries to avoid hitting https://github.com/upx/upx/issues/617