### PR TITLE
fix: Import all platforms from image bundle

### DIFF
--- a/containerd/ctr.go
+++ b/containerd/ctr.go
@@ -20,7 +20,16 @@ func ImportImageArchive(
 	cmd := exec.CommandContext(
 		ctx,
 		"ctr",
-		append(baseArgs, []string{"images", "import", "--no-unpack", archivePath}...)...)
+		append(
+			baseArgs,
+			[]string{
+				"images",
+				"import",
+				"--no-unpack",
+				"--all-platforms",
+				"--digests",
+				archivePath,
+			}...)...)
 	cmdOutput, err := cmd.CombinedOutput()
 	if err != nil {
 		return cmdOutput, fmt.Errorf("failed to import image(s) from image archive: %w", err)


### PR DESCRIPTION
This commit fixes a bug discovered when running containerd in an arm64 container (via qemu)
on Linux. Taking inspiration from
https://github.com/kubernetes-sigs/kind/blob/v0.17.0/pkg/build/nodeimage/imageimporter.go#L60
we now import all platforms and create digest images when importing.

Without this fix, importing would fail with `ctr: image might be filtered out` - this no longer happens.
