### PR TITLE
ci: Upgrade endorama/asdf-parse-tool-versions action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -66,7 +66,7 @@ jobs:
           SKIP_ASDF_CHECK: 1
 
       - name: Gather tool versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.1.0
         id: versions
 
       - name: golangci-lint
@@ -89,7 +89,7 @@ jobs:
           SKIP_ASDF_CHECK: 1
 
       - name: Gather tool versions
-        uses: endorama/asdf-parse-tool-versions@v1
+        uses: endorama/asdf-parse-tool-versions@v1.1.0
         id: versions
 
       - uses: actions/setup-go@v3


### PR DESCRIPTION
Removes warnings about set-output deprecation.
