### PR TITLE
fix: remove hardcoded AWS region when creating ECR lifecycle policies

### DIFF
--- a/cmd/mindthegap/push/helmbundle/helm_bundle.go
+++ b/cmd/mindthegap/push/helmbundle/helm_bundle.go
@@ -120,7 +120,7 @@ func NewCommand(out output.Output) *cobra.Command {
 			if ecr.IsECRRegistry(destRegistryURI.Host()) {
 				prePushFuncs = append(
 					prePushFuncs,
-					ecr.EnsureRepositoryExistsFunc(""),
+					ecr.EnsureRepositoryExistsFunc(destRegistryURI.Host(), ""),
 				)
 			}
 

--- a/cmd/mindthegap/push/imagebundle/image_bundle.go
+++ b/cmd/mindthegap/push/imagebundle/image_bundle.go
@@ -121,7 +121,7 @@ func NewCommand(out output.Output) *cobra.Command {
 			if ecr.IsECRRegistry(destRegistryURI.Host()) {
 				prePushFuncs = append(
 					prePushFuncs,
-					ecr.EnsureRepositoryExistsFunc(ecrLifecyclePolicy),
+					ecr.EnsureRepositoryExistsFunc(destRegistryURI.Host(), ecrLifecyclePolicy),
 				)
 			}
 

--- a/docker/ecr/registry.go
+++ b/docker/ecr/registry.go
@@ -4,13 +4,30 @@
 package ecr
 
 import (
+	"fmt"
 	"regexp"
 )
 
+// regular expression to represent all ECR endpoints. see list at https://docs.aws.amazon.com/general/latest/gr/ecr.html
 var ecrRegistryRegexp = regexp.MustCompile(
-	`^(?:https://)?[a-zA-Z0-9]+\.dkr\.ecr\.[^.]+\.amazonaws\.com/?`,
+	`^(?:https://)?([a-zA-Z0-9]+)\.dkr\.ecr(-fips)?\.([^.]+)\.amazonaws\.com/?`,
 )
 
 func IsECRRegistry(registryAddress string) bool {
 	return ecrRegistryRegexp.MatchString(registryAddress)
+}
+
+func ParseECRRegistry(registryAddress string) (accountID string, fips bool, region string, err error) {
+	matches := ecrRegistryRegexp.FindStringSubmatch(registryAddress)
+	if len(matches) == 0 {
+		return "", false, "", fmt.Errorf("only private Amazon Elastic Container Registry supported.")
+	} else if len(matches) < 3 {
+		return "", false, "", fmt.Errorf("%q is not a valid repository URI for private Amazon Elastic Container Registry.", registryAddress)
+	}
+
+	accountID = matches[1]
+	fips = (matches[2] == "-fips")
+	region = matches[3]
+	err = nil
+	return
 }

--- a/docker/ecr/registry.go
+++ b/docker/ecr/registry.go
@@ -17,12 +17,16 @@ func IsECRRegistry(registryAddress string) bool {
 	return ecrRegistryRegexp.MatchString(registryAddress)
 }
 
-func ParseECRRegistry(registryAddress string) (accountID string, fips bool, region string, err error) {
+func ParseECRRegistry(
+	registryAddress string,
+) (accountID string, fips bool, region string, err error) {
 	matches := ecrRegistryRegexp.FindStringSubmatch(registryAddress)
 	if len(matches) == 0 {
-		return "", false, "", fmt.Errorf("only private Amazon Elastic Container Registry supported.")
+		return "", false, "", fmt.Errorf(
+			"only private Amazon Elastic Container Registry supported")
 	} else if len(matches) < 3 {
-		return "", false, "", fmt.Errorf("%q is not a valid repository URI for private Amazon Elastic Container Registry.", registryAddress)
+		return "", false, "", fmt.Errorf(
+			"%q is not a valid repository URI for private Amazon Elastic Container Registry", registryAddress)
 	}
 
 	accountID = matches[1]

--- a/docker/ecr/registry_test.go
+++ b/docker/ecr/registry_test.go
@@ -89,14 +89,14 @@ func TestParseECRRegistry(t *testing.T) {
 	}, {
 		name:            "public ECR",
 		registryAddress: "public.ecr.aws",
-		wantError:       "only private Amazon Elastic Container Registry supported.",
+		wantError:       "only private Amazon Elastic Container Registry supported",
 		wantAccountID:   "",
 		wantFips:        false,
 		wantRegion:      "",
 	}, {
 		name:            "non ECR",
 		registryAddress: "gcr.io",
-		wantError:       "only private Amazon Elastic Container Registry supported.",
+		wantError:       "only private Amazon Elastic Container Registry supported",
 		wantAccountID:   "",
 		wantFips:        false,
 		wantRegion:      "",

--- a/docker/ecr/repository.go
+++ b/docker/ecr/repository.go
@@ -16,13 +16,17 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func EnsureRepositoryExistsFunc(ecrLifecyclePolicy string) func(
+func EnsureRepositoryExistsFunc(registryAddress string, ecrLifecyclePolicy string) func(
 	_, repositoryName string, _ ...string,
 ) error {
 	return func(
 		_, repositoryName string, _ ...string,
 	) error {
-		cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion("us-west-2"))
+		_, _, region, err := ParseECRRegistry(registryAddress)
+		if err != nil {
+			return fmt.Errorf("failed to parse ECR registry host URI: %w", err)
+		}
+		cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
 		if err != nil {
 			log.Fatalf("unable to load SDK config, %v", err)
 		}

--- a/docker/ecr/repository.go
+++ b/docker/ecr/repository.go
@@ -16,7 +16,7 @@ import (
 	"k8s.io/utils/pointer"
 )
 
-func EnsureRepositoryExistsFunc(registryAddress string, ecrLifecyclePolicy string) func(
+func EnsureRepositoryExistsFunc(registryAddress, ecrLifecyclePolicy string) func(
 	_, repositoryName string, _ ...string,
 ) error {
 	return func(


### PR DESCRIPTION
current implementation will not allow uploading images to ECR in AWS region other than "us-west-2". 
This PR
- extracts region from private ECR registry URI and uses it to create AWS client
- modify ECR registry address to support all endpoints including `fips` https://docs.aws.amazon.com/general/latest/gr/ecr.html
- Unit tests

Steps to reproduce:
- export AWS_REGION=us-west-1
- eval $(maws li eng-ksphere-platform)
- create small image bundle using `dkp create image-bundle --images-file images.yaml`
- upload image bundle to `us-west-1` ECR registry
```shell
❯ dkp push image-bundle --image-bundle images.tar \
--to-registry 999867407951.dkr.ecr.us-west-1.amazonaws.com \
--to-registry-username AWS \
--to-registry-password $(aws ecr get-login-password)
 ✓ Creating temporary directory
 ✓ Unarchiving image bundle "images.tar"
 ✓ Parsing image bundle config
 ✓ Starting temporary Docker registry
2023/03/06 12:38:18 retrying Post "https://999867407951.dkr.ecr.us-west-1.amazonaws.com/v2/library/busybox/blobs/uploads/?from=library%2Fbusybox&mount=sha256%3A66ba00ad3de8677a3fa4bc4ea0fc46ebca0f14db46ca365e7f60833068dd0148&origin=localhost%3A56571": EOF
2023/03/06 12:38:18 retrying Post "https://999867407951.dkr.ecr.us-west-1.amazonaws.com/v2/library/busybox/blobs/uploads/?from=library%2Fbusybox&mount=sha256%3A205dae5015e78dd8c4d302e3db4eb31576fac715b46d099fe09680ba28093a7a&origin=localhost%3A56571": EOF
2023/03/06 12:38:19 retrying Post "https://999867407951.dkr.ecr.us-west-1.amazonaws.com/v2/library/busybox/blobs/uploads/?from=library%2Fbusybox&mount=sha256%3A66ba00ad3de8677a3fa4bc4ea0fc46ebca0f14db46ca365e7f60833068dd0148&origin=localhost%3A56571": EOF
2023/03/06 12:38:19 retrying Post "https://999867407951.dkr.ecr.us-west-1.amazonaws.com/v2/library/busybox/blobs/uploads/?from=library%2Fbusybox&mount=sha256%3A205dae5015e78dd8c4d302e3db4eb31576fac715b46d099fe09680ba28093a7a&origin=localhost%3A56571": EOF
2023/03/06 12:38:23 retrying Post "https://999867407951.dkr.ecr.us-west-1.amazonaws.com/v2/library/busybox/blobs/uploads/?from=library%2Fbusybox&mount=sha256%3A66ba00ad3de8677a3fa4bc4ea0fc46ebca0f14db46ca365e7f60833068dd0148&origin=localhost%3A56571": EOF
 ✗ Copying docker.io/library/busybox:latest (from bundle) to 999867407951.dkr.ecr.us-west-1.amazonaws.com/library/busybox:latest
Post "https://999867407951.dkr.ecr.us-west-1.amazonaws.com/v2/library/busybox/blobs/uploads/?from=library%2Fbusybox&mount=sha256%3A66ba00ad3de8677a3fa4bc4ea0fc46ebca0f14db46ca365e7f60833068dd0148&origin=localhost%3A56571": EOF
```

after fix:
```shell
./dist/mindthegap_darwin_amd64_v1/mindthegap push image-bundle --image-bundle images.tar \
--to-registry 999867407951.dkr.ecr.us-west-1.amazonaws.com \
--to-registry-username AWS \
--to-registry-password $(aws ecr get-login-password)
 ✓ Creating temporary directory
 ✓ Unarchiving image bundle "images.tar"
 ✓ Parsing image bundle config
 ✓ Starting temporary Docker registry
 ✓ Copying docker.io/library/busybox:latest (from bundle) to 999867407951.dkr.ecr.us-west-1.amazonaws.com/library/busybox:latest
```

<img width="1434" alt="image" src="https://user-images.githubusercontent.com/6110931/223247259-caab6bd1-7459-44d2-bb2f-d8d6a0170c0b.png">


 