### PR TITLE
fix: using wrong argument when building ECR repository

### DIFF
--- a/docker/ecr/repository.go
+++ b/docker/ecr/repository.go
@@ -35,7 +35,7 @@ func EnsureRepositoryExistsFunc(registryAddress, ecrLifecyclePolicy string) func
 
 		// if destRegistry has a urlPath prepend it when creating the repository
 		if _, urlPath, found := strings.Cut(destRegistry, "/"); found && len(urlPath) > 0 {
-			repositoryName = path.Join(urlPath, destRegistry)
+			repositoryName = path.Join(urlPath, repositoryName)
 		}
 
 		// Using the Config value, create the S3 client


### PR DESCRIPTION
Made a stupid mistake on the second commit https://github.com/mesosphere/mindthegap/pull/386