### PR TITLE
fix: Separate out source and destination remote options

### DIFF
--- a/cmd/mindthegap/push/bundle/bundle.go
+++ b/cmd/mindthegap/push/bundle/bundle.go
@@ -81,22 +81,24 @@ func NewCommand(out output.Output, bundleCmdName string) *cobra.Command {
 			logs.Debug.SetOutput(out.V(4).InfoWriter())
 			logs.Warn.SetOutput(out.InfoWriter())
 
-			var remoteOpts []remote.Option
+			sourceTLSRoundTripper, err := httputils.InsecureTLSRoundTripper(remote.DefaultTransport)
+			if err != nil {
+				out.Error(err, "error configuring TLS for source registry")
+				os.Exit(2)
+			}
+			sourceRemoteOpts := []remote.Option{remote.WithTransport(sourceTLSRoundTripper)}
 
-			insecure := flags.SkipTLSVerify(destRegistrySkipTLSVerify, destRegistryURI)
-			tlsHostsConfig := httputils.TLSHostsConfig{
-				reg.Address(): httputils.TLSHostConfig{Insecure: true},
-			}
-			if insecure || destRegistryCACertificateFile != "" {
-				tlsHostsConfig[destRegistryURI.Host()] = httputils.TLSHostConfig{
-					Insecure: insecure,
-					CAFile:   destRegistryCACertificateFile,
-				}
-			}
-			transport := httputils.NewConfigurableTLSRoundTripper(
-				tlsHostsConfig,
+			destTLSRoundTripper, err := httputils.TLSConfiguredRoundTripper(
+				remote.DefaultTransport,
+				destRegistryURI.Host(),
+				flags.SkipTLSVerify(destRegistrySkipTLSVerify, destRegistryURI),
+				destRegistryCACertificateFile,
 			)
-			remoteOpts = append(remoteOpts, remote.WithTransport(transport))
+			if err != nil {
+				out.Error(err, "error configuring TLS for destination registry")
+				os.Exit(2)
+			}
+			destRemoteOpts := []remote.Option{remote.WithTransport(destTLSRoundTripper)}
 
 			keychain := authn.DefaultKeychain
 			if destRegistryUsername != "" && destRegistryPassword != "" {
@@ -113,8 +115,7 @@ func NewCommand(out output.Output, bundleCmdName string) *cobra.Command {
 					keychain,
 				)
 			}
-
-			remoteOpts = append(remoteOpts, remote.WithAuthFromKeychain(keychain))
+			destRemoteOpts = append(destRemoteOpts, remote.WithAuthFromKeychain(keychain))
 
 			// Determine type of destination registry.
 			var prePushFuncs []prePushFunc
@@ -129,8 +130,9 @@ func NewCommand(out output.Output, bundleCmdName string) *cobra.Command {
 				err := pushImages(
 					*imagesCfg,
 					reg.Address(),
+					sourceRemoteOpts,
 					destRegistryURI.Address(),
-					remoteOpts,
+					destRemoteOpts,
 					out,
 					prePushFuncs...,
 				)
@@ -143,8 +145,9 @@ func NewCommand(out output.Output, bundleCmdName string) *cobra.Command {
 				err := pushOCIArtifacts(
 					*chartsCfg,
 					fmt.Sprintf("%s/charts", reg.Address()),
+					sourceRemoteOpts,
 					destRegistryURI.Address(),
-					remoteOpts,
+					destRemoteOpts,
 					out,
 					prePushFuncs...,
 				)
@@ -186,8 +189,8 @@ type prePushFunc func(destRegistry, imageName string, imageTags ...string) error
 
 func pushImages(
 	cfg config.ImagesConfig,
-	sourceRegistry, destRegistry string,
-	remoteOpts []remote.Option,
+	sourceRegistry string, sourceRemoteOpts []remote.Option,
+	destRegistry string, destRemoteOpts []remote.Option,
 	out output.Output,
 	prePushFuncs ...prePushFunc,
 ) error {
@@ -231,13 +234,13 @@ func pushImages(
 					return err
 				}
 
-				idx, err := remote.Index(srcRef, remoteOpts...)
+				idx, err := remote.Index(srcRef, sourceRemoteOpts...)
 				if err != nil {
 					out.EndOperation(false)
 					return err
 				}
 
-				if err := remote.WriteIndex(dstRef, idx, remoteOpts...); err != nil {
+				if err := remote.WriteIndex(dstRef, idx, destRemoteOpts...); err != nil {
 					out.EndOperation(false)
 					return err
 				}
@@ -252,8 +255,8 @@ func pushImages(
 
 func pushOCIArtifacts(
 	cfg config.HelmChartsConfig,
-	sourceRegistry, destRegistry string,
-	remoteOpts []remote.Option,
+	sourceRegistry string, sourceRemoteOpts []remote.Option,
+	destRegistry string, destRemoteOpts []remote.Option,
 	out output.Output,
 	prePushFuncs ...prePushFunc,
 ) error {
@@ -289,7 +292,7 @@ func pushOCIArtifacts(
 					out.EndOperation(false)
 					return err
 				}
-				src, err := remote.Image(srcChartRef)
+				src, err := remote.Image(srcChartRef, sourceRemoteOpts...)
 				if err != nil {
 					out.EndOperation(false)
 					return err
@@ -302,7 +305,7 @@ func pushOCIArtifacts(
 					return err
 				}
 
-				if err := remote.Write(destChartRef, src, remoteOpts...); err != nil {
+				if err := remote.Write(destChartRef, src, destRemoteOpts...); err != nil {
 					out.EndOperation(false)
 					return err
 				}

--- a/images/httputils/configurable_tls_transport.go
+++ b/images/httputils/configurable_tls_transport.go
@@ -23,7 +23,7 @@ type configurableTLSTransport struct {
 }
 
 func (rt *configurableTLSTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	tr := rt.delegateTransport.Clone()
+	tr := rt.delegateTransport
 
 	if tr.TLSClientConfig.RootCAs == nil {
 		systemPool, err := tlsconfig.SystemCertPool()

--- a/images/httputils/configurable_tls_transport.go
+++ b/images/httputils/configurable_tls_transport.go
@@ -14,23 +14,20 @@ import (
 	"github.com/docker/docker/registry"
 	"github.com/docker/go-connections/tlsconfig"
 	"github.com/google/go-containerregistry/pkg/logs"
-	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
-type configurableTLSTransport struct {
-	cfg               TLSHostsConfig
-	delegateTransport *http.Transport
-}
+func TLSConfiguredRoundTripper(
+	rt http.RoundTripper,
+	host string,
+	insecureTLSSkipVerify bool,
+	caCertificateFile string,
+) (http.RoundTripper, error) {
+	tr := rt.(*http.Transport).Clone()
 
-func (rt *configurableTLSTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	tr := rt.delegateTransport.Clone()
-	// This function creates new http.Transport for every request.
-	// When creating an image bundle this results in ~8x of the number of images.
-	// Because this happens relatively fast, the OS may not clean up the TCP connections in time,
-	// leading to a "socket: too many open files" error.
-	// Because we need to use a new http.Transport based on the request's Host, the http.Transport cannot be reused,
-	// therefore we also need to force close the idle connections.
-	defer tr.CloseIdleConnections()
+	if insecureTLSSkipVerify {
+		tr.TLSClientConfig.InsecureSkipVerify = insecureTLSSkipVerify
+		return tr, nil
+	}
 
 	if tr.TLSClientConfig.RootCAs == nil {
 		systemPool, err := tlsconfig.SystemCertPool()
@@ -38,16 +35,7 @@ func (rt *configurableTLSTransport) RoundTrip(req *http.Request) (*http.Response
 			return nil, fmt.Errorf("unable to get system cert pool: %v", err)
 		}
 		tr.TLSClientConfig.RootCAs = systemPool
-	} else {
-		tr.TLSClientConfig.RootCAs = tr.TLSClientConfig.RootCAs.Clone()
 	}
-
-	host := req.Host
-	if host == "" {
-		host = req.URL.Host
-	}
-
-	tlsHostConfig, tlsHostConfigFound := rt.cfg[host]
 
 	// Always returns nil error...
 	hostDockerCertsDir, _ := registry.HostCertsDir(host)
@@ -66,46 +54,28 @@ func (rt *configurableTLSTransport) RoundTrip(req *http.Request) (*http.Response
 		}
 	}
 
-	tr.TLSClientConfig.InsecureSkipVerify = tlsHostConfigFound && tlsHostConfig.Insecure
-
-	if tlsHostConfigFound && tlsHostConfig.CAFile != "" {
-		b, err := os.ReadFile(tlsHostConfig.CAFile)
+	if caCertificateFile != "" {
+		b, err := os.ReadFile(caCertificateFile)
 		if err != nil {
 			return nil, fmt.Errorf("failed to read specified CA file: %w", err)
 		}
 		_ = tr.TLSClientConfig.RootCAs.AppendCertsFromPEM(b)
 	}
 
-	return tr.RoundTrip(req)
-}
-
-type TLSHostConfig struct {
-	CAFile   string // Path of the PEM-encoded server trusted root certificates.
-	Insecure bool   // Server should be accessed without verifying the certificate. For testing only.
-}
-
-type TLSHostsConfig map[string]TLSHostConfig
-
-func NewConfigurableTLSRoundTripper(
-	cfg TLSHostsConfig,
-) http.RoundTripper {
-	var tr http.RoundTripper = remote.DefaultTransport.(*http.Transport).Clone()
+	rt = tr
 
 	// Add any http headers if they are set in the config file.
 	cf, err := config.Load(os.Getenv("DOCKER_CONFIG"))
 	if err != nil {
 		logs.Debug.Printf("failed to read config file: %v", err)
 	} else if len(cf.HTTPHeaders) != 0 {
-		tr = &headerTransport{
+		rt = &headerTransport{
 			inner:       tr,
 			httpHeaders: cf.HTTPHeaders,
 		}
 	}
 
-	return &configurableTLSTransport{
-		cfg:               cfg,
-		delegateTransport: tr.(*http.Transport),
-	}
+	return rt, nil
 }
 
 // headerTransport sets headers on outgoing requests.

--- a/images/httputils/insecure_tls_transport.go
+++ b/images/httputils/insecure_tls_transport.go
@@ -1,0 +1,10 @@
+// Copyright 2021 D2iQ, Inc. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package httputils
+
+import "net/http"
+
+func InsecureTLSRoundTripper(rt http.RoundTripper) (http.RoundTripper, error) {
+	return TLSConfiguredRoundTripper(rt, "", true, "")
+}

--- a/test/e2e/imagebundle/push_image_bundle_test.go
+++ b/test/e2e/imagebundle/push_image_bundle_test.go
@@ -144,6 +144,14 @@ var _ = Describe("Push Bundle", func() {
 
 		Expect(cmd.Execute()).To(Succeed())
 
+		testRoundTripper, err := httputils.TLSConfiguredRoundTripper(
+			remote.DefaultTransport,
+			net.JoinHostPort(ipAddr.String(), strconv.Itoa(port)),
+			false,
+			caCertFile,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
 		helpers.ValidateImageIsAvailable(
 			GinkgoT(),
 			ipAddr.String(),
@@ -154,15 +162,7 @@ var _ = Describe("Push Bundle", func() {
 				OS:           "linux",
 				Architecture: runtime.GOARCH,
 			}},
-			remote.WithTransport(
-				httputils.NewConfigurableTLSRoundTripper(
-					httputils.TLSHostsConfig{
-						net.JoinHostPort(ipAddr.String(), strconv.Itoa(port)): httputils.TLSHostConfig{
-							CAFile: caCertFile,
-						},
-					},
-				),
-			),
+			remote.WithTransport(testRoundTripper),
 		)
 
 		Expect(reg.Shutdown(context.Background())).To((Succeed()))
@@ -218,6 +218,14 @@ var _ = Describe("Push Bundle", func() {
 
 		Expect(cmd.Execute()).To(Succeed())
 
+		testRoundTripper, err := httputils.TLSConfiguredRoundTripper(
+			remote.DefaultTransport,
+			net.JoinHostPort(ipAddr.String(), strconv.Itoa(port)),
+			false,
+			caCertFile,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
 		helpers.ValidateImageIsAvailable(
 			GinkgoT(),
 			ipAddr.String(),
@@ -228,15 +236,7 @@ var _ = Describe("Push Bundle", func() {
 				OS:           "linux",
 				Architecture: runtime.GOARCH,
 			}},
-			remote.WithTransport(
-				httputils.NewConfigurableTLSRoundTripper(
-					httputils.TLSHostsConfig{
-						net.JoinHostPort(ipAddr.String(), strconv.Itoa(port)): httputils.TLSHostConfig{
-							CAFile: caCertFile,
-						},
-					},
-				),
-			),
+			remote.WithTransport(testRoundTripper),
 		)
 
 		Expect(reg.Shutdown(context.Background())).To((Succeed()))

--- a/test/e2e/imagebundle/serve_image_bundle_test.go
+++ b/test/e2e/imagebundle/serve_image_bundle_test.go
@@ -124,6 +124,14 @@ var _ = Describe("Serve Bundle", func() {
 
 		helpers.WaitForTCPPort(GinkgoT(), ipAddr.String(), port)
 
+		testRoundTripper, err := httputils.TLSConfiguredRoundTripper(
+			remote.DefaultTransport,
+			net.JoinHostPort(ipAddr.String(), strconv.Itoa(port)),
+			false,
+			caCertFile,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
 		helpers.ValidateImageIsAvailable(
 			GinkgoT(),
 			ipAddr.String(),
@@ -134,15 +142,7 @@ var _ = Describe("Serve Bundle", func() {
 				OS:           "linux",
 				Architecture: runtime.GOARCH,
 			}},
-			remote.WithTransport(
-				httputils.NewConfigurableTLSRoundTripper(
-					httputils.TLSHostsConfig{
-						net.JoinHostPort(ipAddr.String(), strconv.Itoa(port)): httputils.TLSHostConfig{
-							CAFile: caCertFile,
-						},
-					},
-				),
-			),
+			remote.WithTransport(testRoundTripper),
 		)
 
 		close(stopCh)


### PR DESCRIPTION
~No need to Clone delegateTransport on every function call, we can reuse the same http.Transport for every call.~
Close idle connections.