### PR TITLE
fix: Unset REGISTRY_ prefixed env vars

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -42,11 +42,11 @@ linters:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    packages:
-      - k8s.io/kubernetes
-    packages-with-error-messages:
-      k8s.io/kubernetes: "do not use k8s.io/kubernetes directly"
+    rules:
+      main:
+        deny:
+          - pkg: k8s.io/kubernetes
+            desc: "do not use k8s.io/kubernetes directly"
   errcheck:
     exclude-functions:
       - encoding/json.Marshal


### PR DESCRIPTION
The Docker registry that is embedded in mindthegap reads `REGISTRY_` prefixed
environment variables, which could lead to unexpected behaviour depending on
the environment. This commit unsets these environment variables to ensure
consistent behaviour independent of environment.

Fixes D2IQ-97438.
