### PR TITLE
build: Tweak golangci-lint configuration

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 run:
-  timeout: 5m
+  timeout: 10m
   go: '1.17'
 
 linters:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@
 
 run:
   timeout: 10m
-  go: '1.17'
 
 linters:
   disable-all: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,9 @@ repos:
   rev: v1.0.0-rc.1
   hooks:
   - id: go-mod-tidy
+    stages: [commit]
   - id: golangci-lint-mod
+    stages: [commit]
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.4.0
   hooks:

--- a/cmd/mindthegap/push/bundle/bundle.go
+++ b/cmd/mindthegap/push/bundle/bundle.go
@@ -142,7 +142,9 @@ func NewCommand(out output.Output, bundleCmdName string) *cobra.Command {
 				// If a password hasn't been specified, then try to retrieve a token.
 				if destRegistryPassword == "" {
 					out.StartOperation("Retrieving ECR credentials")
-					destRegistryUsername, destRegistryPassword, err = ecr.RetrieveUsernameAndToken(ecrClient)
+					destRegistryUsername, destRegistryPassword, err = ecr.RetrieveUsernameAndToken(
+						ecrClient,
+					)
 					if err != nil {
 						out.EndOperationWithStatus(output.Failure())
 						return fmt.Errorf(
@@ -171,11 +173,17 @@ func NewCommand(out output.Output, bundleCmdName string) *cobra.Command {
 			}
 			destRemoteOpts = append(destRemoteOpts, remote.WithAuthFromKeychain(keychain))
 
-			srcRegistry, err := name.NewRegistry(reg.Address(), name.Insecure, name.StrictValidation)
+			srcRegistry, err := name.NewRegistry(
+				reg.Address(),
+				name.Insecure,
+				name.StrictValidation,
+			)
 			if err != nil {
 				return err
 			}
-			destRegistry, err := name.NewRegistry(destRegistryURI.Host(), append(destNameOpts, name.StrictValidation)...)
+			destRegistry, err := name.NewRegistry(
+				destRegistryURI.Host(),
+				append(destNameOpts, name.StrictValidation)...)
 			if err != nil {
 				return err
 			}
@@ -297,7 +305,12 @@ func pushImages(
 				}
 			}
 
-			existingImageTags, err := getExistingImages(context.Background(), onExistingTag, puller, destRepository)
+			existingImageTags, err := getExistingImages(
+				context.Background(),
+				onExistingTag,
+				puller,
+				destRepository,
+			)
 			if err != nil {
 				return err
 			}
@@ -364,7 +377,10 @@ func pushOCIArtifacts(
 		chartNames := repoConfig.SortedChartNames()
 
 		for _, chartName := range chartNames {
-			srcRepository := sourceRegistry.Repo(strings.TrimLeft(sourceRegistryPath, "/"), chartName)
+			srcRepository := sourceRegistry.Repo(
+				strings.TrimLeft(sourceRegistryPath, "/"),
+				chartName,
+			)
 			destRepository := destRegistry.Repo(strings.TrimLeft(destRegistryPath, "/"), chartName)
 
 			chartVersions := repoConfig.Charts[chartName]
@@ -406,7 +422,10 @@ func pushOCIArtifacts(
 }
 
 func getExistingImages(
-	ctx context.Context, onExistingTag onExistingTagMode, puller *remote.Puller, repo name.Repository,
+	ctx context.Context,
+	onExistingTag onExistingTagMode,
+	puller *remote.Puller,
+	repo name.Repository,
 ) (map[string]struct{}, error) {
 	if onExistingTag == Overwrite {
 		return nil, nil

--- a/docker/ecr/repository.go
+++ b/docker/ecr/repository.go
@@ -102,7 +102,9 @@ func RetrieveUsernameAndToken(ecrClient *ecr.Client) (username, token string, er
 	// guaranteed.
 	base64EncodedAuthorizationToken := aws.ToString(out.AuthorizationData[0].AuthorizationToken)
 
-	decodedAuthorizationToken, err := base64.StdEncoding.DecodeString(base64EncodedAuthorizationToken)
+	decodedAuthorizationToken, err := base64.StdEncoding.DecodeString(
+		base64EncodedAuthorizationToken,
+	)
 	if err != nil {
 		return "", "", err
 	}

--- a/make/go.mk
+++ b/make/go.mk
@@ -120,8 +120,8 @@ endif
 .PHONY: lint.%
 lint.%: ## Runs golangci-lint for a specific module
 lint.%: ; $(info $(M) linting $* module)
-	$(if $(filter-out root,$*),cd $* && )golines -w $$(go list ./... | sed "s|^$$(go list -m)|.|")
 	$(if $(filter-out root,$*),cd $* && )golangci-lint run --fix --config=$(GOLANGCI_CONFIG_FILE)
+	$(if $(filter-out root,$*),cd $* && )golines -w $$(go list ./... | sed "s|^$$(go list -m)|.|")
 	$(if $(filter-out root,$*),cd $* && )go fix ./...
 
 .PHONY: mod-tidy


### PR DESCRIPTION
- build: Increase golangci-lint timeout for slow CI machines
- build: Relax go version config for golangci-lint
- refactor: Fix up golines config for linting
