### PR TITLE
fix: Hide crane warnings by default

### DIFF
--- a/cmd/mindthegap/create/imagebundle/image_bundle.go
+++ b/cmd/mindthegap/create/imagebundle/image_bundle.go
@@ -112,7 +112,7 @@ func NewCommand(out output.Output) *cobra.Command {
 			out.EndOperationWithStatus(output.Success())
 
 			logs.Debug.SetOutput(out.V(4).InfoWriter())
-			logs.Warn.SetOutput(out.InfoWriter())
+			logs.Warn.SetOutput(out.V(2).InfoWriter())
 
 			// Sort registries for deterministic ordering.
 			regNames := cfg.SortedRegistryNames()

--- a/cmd/mindthegap/push/bundle/bundle.go
+++ b/cmd/mindthegap/push/bundle/bundle.go
@@ -103,7 +103,7 @@ func NewCommand(out output.Output, bundleCmdName string) *cobra.Command {
 			out.EndOperationWithStatus(output.Success())
 
 			logs.Debug.SetOutput(out.V(4).InfoWriter())
-			logs.Warn.SetOutput(out.InfoWriter())
+			logs.Warn.SetOutput(out.V(2).InfoWriter())
 
 			sourceTLSRoundTripper, err := httputils.InsecureTLSRoundTripper(remote.DefaultTransport)
 			if err != nil {


### PR DESCRIPTION
Warnings such as the following cause confusion for no reason - everything is working as expected:

```
2023/09/13 17:32:25 retrying without mount: POST
UNAUTHORIZED: project istio not found: project istio not found
```
