### PR TITLE
ci: Switch to jetify-com/devbox-install-action

### DIFF
--- a/.github/workflows/checks-macos.yml
+++ b/.github/workflows/checks-macos.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
         env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 
@@ -59,7 +59,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 
@@ -119,7 +119,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,7 +34,7 @@ jobs:
           languages: ${{ matrix.language }}
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 

--- a/.github/workflows/devbox-update.yaml
+++ b/.github/workflows/devbox-update.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 

--- a/.github/workflows/release-tag.yaml
+++ b/.github/workflows/release-tag.yaml
@@ -26,7 +26,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install devbox
-        uses: jetpack-io/devbox-install-action@v0.8.0
+        uses: jetify-com/devbox-install-action@v0.9.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
GH org was renamed as part of company rebranding.
