### PR TITLE
build: Specify go1.22.2 as toolchain to fix govulncheck issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ module github.com/mesosphere/mindthegap
 
 go 1.22
 
+toolchain go1.22.2
+
 require (
 	github.com/aws/aws-sdk-go-v2 v1.26.1
 	github.com/aws/aws-sdk-go-v2/config v1.27.11


### PR DESCRIPTION
Nix (and therefore devbox) has been slow in rolling out go1.22.2, which
contains CVE fixes. Current version go1.22.1 causes govulncheck to
report valid vulnerabilities in `net/http` package. go1.21 introduced
toolchain management via `go.mod` file with `toolchain` directive. This
commit specifies go1.22.2 as the toolchain to use and hence fixes the
govulncheck issues.

This does mean that go versions have to be managed in multiple places so
this is a stop-gap until Nix releases go1.22.2 to nixpkgs-unstable
channel.
