### PR TITLE
fix: Support published Helm charts with different name format

### DIFF
--- a/test/e2e/helmbundle/push_bundle_test.go
+++ b/test/e2e/helmbundle/push_bundle_test.go
@@ -83,6 +83,15 @@ var _ = Describe("Push Bundle", func() {
 			helm.InsecureSkipTLSverifyOpt(),
 		)
 
+		helpers.ValidateChartIsAvailable(
+			GinkgoT(),
+			"127.0.0.1",
+			port,
+			"node-feature-discovery",
+			"0.15.2",
+			helm.InsecureSkipTLSverifyOpt(),
+		)
+
 		Expect(reg.Shutdown(context.Background())).To((Succeed()))
 
 		Eventually(done).Should(BeClosed())

--- a/test/e2e/helmbundle/serve_bundle_test.go
+++ b/test/e2e/helmbundle/serve_bundle_test.go
@@ -75,6 +75,15 @@ var _ = Describe("Serve Bundle", func() {
 			helm.InsecureSkipTLSverifyOpt(),
 		)
 
+		helpers.ValidateChartIsAvailable(
+			GinkgoT(),
+			"127.0.0.1",
+			port,
+			"node-feature-discovery",
+			"0.15.2",
+			helm.InsecureSkipTLSverifyOpt(),
+		)
+
 		close(stopCh)
 
 		Eventually(done).Should(BeClosed())

--- a/test/e2e/helmbundle/testdata/create-success.yaml
+++ b/test/e2e/helmbundle/testdata/create-success.yaml
@@ -2,9 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 repositories:
-  jetstack:
+  stefanprodan:
     repoURL: https://stefanprodan.github.io/podinfo
     charts:
       podinfo:
       - "6.2.0"
       - "6.1.0"
+  nfd:
+    repoURL: https://kubernetes-sigs.github.io/node-feature-discovery/charts/
+    charts:
+      node-feature-discovery:
+      - "0.15.2"


### PR DESCRIPTION
Currently `mindthegap create helm-bundle` fails if the chart published in
the helm repo has a different name to the expected format
`<chartName>-<chartVersion>.tgz`. An example that hit this issue is the NFD
chart that is published with the name
`<chartName>-chart-<chartVersion>.tgz`.

This commit fixes the issue by first finding the download URL from the
Helm repo index and then using the existing `GetChartFromURL` function
to download the chart. This already correctly uses the basename of the
published chart file and hence doesn't hit the above issue.

Tested to be working:

```bash
$ cat repos.yaml
repositories:
  nfd:
    repoURL: https://kubernetes-sigs.github.io/node-feature-discovery/charts/
    charts:
      node-feature-discovery:
      - 0.15.2

$ ./dist/mindthegap_darwin_arm64/mindthegap create helm-bundle --helm-charts-file=repos.yaml --overwrite
 ✓ Parsing Helm chart bundle config
 ✓ Creating temporary OCI registry directory
 ✓ Starting temporary OCI registry
 ✓ Creating temporary chart storage directory
 ✓ Fetching Helm chart node-feature-discovery (versions [0.15.2]) from nfd
(https://kubernetes-sigs.github.io/node-feature-discovery/charts/)
 ✓ Archiving Helm charts to helm-charts.tar

$ ./dist/mindthegap_darwin_arm64/mindthegap serve bundle --bundle helm-charts.tar &
 ✓ Creating temporary directory
 ✓ Unarchiving image bundle "helm-charts.tar"
 ✓ Parsing Helm charts bundle config
 ✓ Creating Docker registry
Listening on 127.0.0.1:58639

$ crane ls 127.0.0.1:58783/charts/node-feature-discovery
0.15.2
```
