### PR TITLE
build: Ignore long lines for commit shas

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -16,7 +16,7 @@ line-length=120
 
 [ignore-body-lines]
 # Ignore dependabot long lines.
-regex=^Bumps .+ from .+ to .+\.$
+regex=^(Bumps .+ from .+ to .+\.$|- \[Commits\])
 
 [contrib-title-conventional-commits]
 # Specify allowed commit types. For details see: https://www.conventionalcommits.org/


### PR DESCRIPTION
Now that workflows use SHA-pinned actions rather than tagged versions,
dependabot commits are long causing failures in gitlint. This commit
fixes that by ignoring the specific lines that cause this issue.
