### PR TITLE
test(e2e): Specify architecture for test images in e2e

### DIFF
--- a/test/e2e/imagebundle/push_bundle_test.go
+++ b/test/e2e/imagebundle/push_bundle_test.go
@@ -155,6 +155,7 @@ var _ = Describe("Push Bundle", func() {
 					GinkgoT(),
 					bundleFile,
 					filepath.Join("testdata", "create-success.yaml"),
+					"linux/"+runtime.GOARCH,
 				)
 
 				runTest(registryHost, registryScheme, registryPath, registryInsecure)
@@ -203,6 +204,7 @@ var _ = Describe("Push Bundle", func() {
 					GinkgoT(),
 					bundleFile,
 					filepath.Join("testdata", "create-success.yaml"),
+					"linux/"+runtime.GOARCH,
 				)
 			})
 
@@ -285,6 +287,7 @@ var _ = Describe("Push Bundle", func() {
 					GinkgoT(),
 					bundleFile,
 					filepath.Join("testdata", "create-success.yaml"),
+					"linux/"+runtime.GOARCH,
 				)
 
 				DeferCleanup(GinkgoWriter.ClearTeeWriters)

--- a/test/e2e/imagebundle/serve_bundle_test.go
+++ b/test/e2e/imagebundle/serve_bundle_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Serve Bundle", func() {
 			GinkgoT(),
 			bundleFile,
 			filepath.Join("testdata", "create-success.yaml"),
+			"linux/"+runtime.GOARCH,
 		)
 
 		port, err := freeport.GetFreePort()
@@ -102,6 +103,7 @@ var _ = Describe("Serve Bundle", func() {
 			GinkgoT(),
 			bundleFile,
 			filepath.Join("testdata", "create-success.yaml"),
+			"linux/"+runtime.GOARCH,
 		)
 
 		port, err := freeport.GetFreePort()


### PR DESCRIPTION
This allows running the e2e tests on arm64 dev machines.
