### PR TITLE
ci: Remove redundant env var

### DIFF
--- a/.github/workflows/checks-macos.yml
+++ b/.github/workflows/checks-macos.yml
@@ -16,8 +16,6 @@ on:
 defaults:
   run:
     shell: bash
-env:
-  TASK_X_ANY_VARIABLES: 1
 jobs:
   build-and-run:
     runs-on: macos-13

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,8 +16,6 @@ permissions:
 defaults:
   run:
     shell: bash
-env:
-  TASK_X_ANY_VARIABLES: 1
 jobs:
   unit-test:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This was used for taskfile experiment which is now integrated
so this env var is no longer needed.
