### PR TITLE
build: Use go 1.22.5 toolchain to fix CVE

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/mesosphere/mindthegap
 
 go 1.22.0
 
-toolchain go1.22.4
+toolchain go1.22.5
 
 // TODO: This could be removed after https://github.com/mholt/archiver/pull/396 merged
 replace github.com/mholt/archiver/v3 => github.com/anchore/archiver/v3 v3.5.2


### PR DESCRIPTION
This was highlighted by failing govulncheck builds in
other PRs.

Fixes https://pkg.go.dev/vuln/GO-2024-2963.
