### PR TITLE
feat: Optionally force convert to OCI media types on push

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ mindthegap push image-bundle --image-bundle <path/to/images.tar> \
 
 All images in the image bundle tar file will be pushed to the target OCI registry.
 
+Some registries (e.g. [zot](https://zotregistry.dev/) are strict about what media types they support. If you are pushing
+to a registry that only accepts OCI media types, then specify the `--force-oci-media-types` flag. This will internally
+convert any images that currently use Docker media types (`application/vnd.docker.*`) to OCI compatible media types
+(`application/vnd.oci.*`). Using the images via any container runtime does not change.
+
 #### Serving an image bundle
 
 **_This command is deprecated - see [Serving a bundle](#serving-a-bundle-supports-both-image-or-helm-chart)_**

--- a/images/manifest.go
+++ b/images/manifest.go
@@ -5,6 +5,7 @@ package images
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
@@ -145,7 +146,17 @@ func indexForSinglePlatformImage(
 			},
 		},
 	)
-	index = mutate.IndexMediaType(index, types.DockerManifestList)
+
+	imgMediaType, err := img.MediaType()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get image media type for image %q: %w", ref, err)
+	}
+	idxMediaType := types.OCIImageIndex
+	if strings.Contains(string(imgMediaType), types.DockerVendorPrefix) {
+		idxMediaType = types.DockerManifestList
+	}
+
+	index = mutate.IndexMediaType(index, idxMediaType)
 
 	if len(platforms) == 0 {
 		return index, nil

--- a/images/manifest.go
+++ b/images/manifest.go
@@ -112,7 +112,7 @@ func platformsIgnoringVariantIfNotSpecified(platforms ...v1.Platform) match.Matc
 
 func indexForSinglePlatformImage(
 	ref name.Reference,
-	img v1.Image,
+	image v1.Image,
 	platforms ...string,
 ) (v1.ImageIndex, error) {
 	if len(platforms) > 1 {
@@ -124,39 +124,40 @@ func indexForSinglePlatformImage(
 			)
 	}
 
-	imgConfig, err := img.ConfigFile()
+	imageConfig, err := image.ConfigFile()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image config for image %q: %w", ref, err)
 	}
 
-	imgPlatform := v1.Platform{
-		OS:           imgConfig.OS,
-		OSVersion:    imgConfig.OSVersion,
-		Architecture: imgConfig.Architecture,
-		Variant:      imgConfig.Variant,
+	imagePlatform := v1.Platform{
+		OS:           imageConfig.OS,
+		OSVersion:    imageConfig.OSVersion,
+		Architecture: imageConfig.Architecture,
+		Variant:      imageConfig.Variant,
 	}
 
 	var index v1.ImageIndex = empty.Index
 	index = mutate.AppendManifests(
 		index,
 		mutate.IndexAddendum{
-			Add: img,
+			Add: image,
 			Descriptor: v1.Descriptor{
-				Platform: &imgPlatform,
+				Platform: &imagePlatform,
 			},
 		},
 	)
 
-	imgMediaType, err := img.MediaType()
+	imageMediaType, err := image.MediaType()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image media type for image %q: %w", ref, err)
 	}
-	idxMediaType := types.OCIImageIndex
-	if strings.Contains(string(imgMediaType), types.DockerVendorPrefix) {
-		idxMediaType = types.DockerManifestList
+
+	indexMediaType := types.OCIImageIndex
+	if strings.Contains(string(imageMediaType), types.DockerVendorPrefix) {
+		indexMediaType = types.DockerManifestList
 	}
 
-	index = mutate.IndexMediaType(index, idxMediaType)
+	index = mutate.IndexMediaType(index, indexMediaType)
 
 	if len(platforms) == 0 {
 		return index, nil
@@ -167,17 +168,17 @@ func indexForSinglePlatformImage(
 		return nil, fmt.Errorf("invalid platform %q: %w", platforms[0], err)
 	}
 
-	imgPlatformForComparison := imgPlatform
+	imagePlatformForComparison := imagePlatform
 	if v1Platform.Variant == "" {
-		imgPlatformForComparison.Variant = ""
+		imagePlatformForComparison.Variant = ""
 	}
 
-	if !imgPlatformForComparison.Equals(*v1Platform) {
+	if !imagePlatformForComparison.Equals(*v1Platform) {
 		return nil, fmt.Errorf(
 			"requested image %q does not match requested platform %q (image is for %q)",
 			ref,
 			v1Platform,
-			imgPlatform,
+			imagePlatform,
 		)
 	}
 

--- a/test/e2e/imagebundle/helpers/helpers.go
+++ b/test/e2e/imagebundle/helpers/helpers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
@@ -189,6 +190,7 @@ func ValidateImageIsAvailable(
 	port int,
 	registryPath, image, tag string,
 	platforms []*v1.Platform,
+	forceOCIMediaTypes bool,
 	opts ...remote.Option,
 ) {
 	t.Helper()
@@ -205,6 +207,9 @@ func ValidateImageIsAvailable(
 
 	manifest, err := idx.IndexManifest()
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())
+	if forceOCIMediaTypes {
+		gomega.ExpectWithOffset(1, manifest.MediaType).To(gomega.Equal(types.OCIImageIndex))
+	}
 
 	gomega.ExpectWithOffset(1, manifest.Manifests).To(gomega.HaveLen(len(platforms)))
 

--- a/test/e2e/imagebundle/serve_bundle_test.go
+++ b/test/e2e/imagebundle/serve_bundle_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Serve Bundle", func() {
 				OS:           "linux",
 				Architecture: runtime.GOARCH,
 			}},
+			false,
 		)
 
 		close(stopCh)
@@ -146,6 +147,7 @@ var _ = Describe("Serve Bundle", func() {
 				OS:           "linux",
 				Architecture: runtime.GOARCH,
 			}},
+			false,
 			remote.WithTransport(testRoundTripper),
 		)
 


### PR DESCRIPTION
This enables support for stricter registries, such as zot, as well as enabling
users to move to a future without vendor specific Docker media types.
