### PR TITLE
fix: Allow TLS to pull chart from OCI repository

### DIFF
--- a/cmd/mindthegap/create/bundle/bundle.go
+++ b/cmd/mindthegap/create/bundle/bundle.go
@@ -400,7 +400,6 @@ func pullCharts(
 					repoConfig.RepoURL,
 					chartName,
 					chartVersion,
-					[]helm.ConfigOpt{helm.RegistryClientConfigOpt()},
 					opts...,
 				)
 				if err != nil {

--- a/helm/client.go
+++ b/helm/client.go
@@ -99,37 +99,17 @@ func CAFileOpt(caFile string) action.PullOpt {
 	}
 }
 
-type ConfigOpt func(*action.Configuration) error
-
-func RegistryClientConfigOpt(opts ...registry.ClientOption) ConfigOpt {
-	return func(cfg *action.Configuration) error {
-		cl, err := registry.NewClient(opts...)
-		if err != nil {
-			return fmt.Errorf("failed to create registry client: %w", err)
-		}
-
-		cfg.RegistryClient = cl
-
-		return nil
+func CertFileOpt(certFile string) action.PullOpt {
+	return func(p *action.Pull) {
+		p.CertFile = certFile
 	}
 }
 
 func (c *Client) GetChartFromRepo(
 	outputDir, repoURL, chartName, chartVersion string,
-	configOpts []ConfigOpt,
 	extraPullOpts ...action.PullOpt,
 ) (string, error) {
 	cfg := &action.Configuration{Log: c.out.V(4).Infof}
-
-	if registry.IsOCI(chartName) {
-		configOpts = append([]ConfigOpt{RegistryClientConfigOpt()}, configOpts...)
-	}
-
-	for _, f := range configOpts {
-		if err := f(cfg); err != nil {
-			return "", fmt.Errorf("failed to configure helm client: %w", err)
-		}
-	}
 
 	pull := action.NewPullWithOpts(
 		append(

--- a/helm/client.go
+++ b/helm/client.go
@@ -99,12 +99,6 @@ func CAFileOpt(caFile string) action.PullOpt {
 	}
 }
 
-func CertFileOpt(certFile string) action.PullOpt {
-	return func(p *action.Pull) {
-		p.CertFile = certFile
-	}
-}
-
 func (c *Client) GetChartFromRepo(
 	outputDir, repoURL, chartName, chartVersion string,
 	extraPullOpts ...action.PullOpt,

--- a/test/e2e/helmbundle/helpers/helpers.go
+++ b/test/e2e/helmbundle/helpers/helpers.go
@@ -194,7 +194,6 @@ func ValidateChartIsAvailable(
 		"",
 		fmt.Sprintf("%s://%s:%d/charts/%s", helm.OCIScheme, addr, port, chartName),
 		chartVersion,
-		[]helm.ConfigOpt{helm.RegistryClientConfigOpt()},
 		pullOpts...,
 	)
 	gomega.ExpectWithOffset(1, err).NotTo(gomega.HaveOccurred())

--- a/test/e2e/helmbundle/serve_bundle_test.go
+++ b/test/e2e/helmbundle/serve_bundle_test.go
@@ -93,7 +93,7 @@ var _ = Describe("Serve Helm Bundle", func() {
 		ipAddr := helpers.GetFirstNonLoopbackIP(GinkgoT())
 
 		tempCertDir := GinkgoT().TempDir()
-		_, _, certFile, keyFile := helpers.GenerateCertificateAndKeyWithIPSAN(
+		caCertFile, _, certFile, keyFile := helpers.GenerateCertificateAndKeyWithIPSAN(
 			GinkgoT(),
 			tempCertDir,
 			ipAddr,
@@ -126,8 +126,9 @@ var _ = Describe("Serve Helm Bundle", func() {
 
 		helpers.WaitForTCPPort(GinkgoT(), ipAddr.String(), port)
 
-		// TODO Reenable once Helm supports custom CA certs and self-signed certs.
-		// helpers.ValidateChartIsAvailable(GinkgoT(), "127.0.0.1", port, "podinfo", "6.2.0", helm.CAFileOpt(caCertFile))
+		helpers.ValidateChartIsAvailable(GinkgoT(), ipAddr.String(), port, "podinfo", "6.2.0", helm.CAFileOpt(caCertFile), helm.CertFileOpt(certFile))
+
+		helpers.ValidateChartIsAvailable(GinkgoT(), ipAddr.String(), port, "node-feature-discovery", "0.15.2", helm.CAFileOpt(caCertFile), helm.CertFileOpt(certFile))
 
 		close(stopCh)
 

--- a/test/e2e/helmbundle/serve_bundle_test.go
+++ b/test/e2e/helmbundle/serve_bundle_test.go
@@ -126,9 +126,9 @@ var _ = Describe("Serve Helm Bundle", func() {
 
 		helpers.WaitForTCPPort(GinkgoT(), ipAddr.String(), port)
 
-		helpers.ValidateChartIsAvailable(GinkgoT(), ipAddr.String(), port, "podinfo", "6.2.0", helm.CAFileOpt(caCertFile), helm.CertFileOpt(certFile))
+		helpers.ValidateChartIsAvailable(GinkgoT(), ipAddr.String(), port, "podinfo", "6.2.0", helm.CAFileOpt(caCertFile))
 
-		helpers.ValidateChartIsAvailable(GinkgoT(), ipAddr.String(), port, "node-feature-discovery", "0.15.2", helm.CAFileOpt(caCertFile), helm.CertFileOpt(certFile))
+		helpers.ValidateChartIsAvailable(GinkgoT(), ipAddr.String(), port, "node-feature-discovery", "0.15.2", helm.CAFileOpt(caCertFile))
 
 		close(stopCh)
 

--- a/test/e2e/helmbundle/serve_bundle_test.go
+++ b/test/e2e/helmbundle/serve_bundle_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/mesosphere/mindthegap/test/e2e/helmbundle/helpers"
 )
 
-var _ = Describe("Serve Bundle", func() {
+var _ = Describe("Serve Helm Bundle", func() {
 	var (
 		bundleFile string
 		cmd        *cobra.Command

--- a/test/e2e/imagebundle/serve_bundle_test.go
+++ b/test/e2e/imagebundle/serve_bundle_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/mesosphere/mindthegap/test/e2e/imagebundle/helpers"
 )
 
-var _ = Describe("Serve Bundle", func() {
+var _ = Describe("Serve Image Bundle", func() {
 	var (
 		bundleFile string
 		cmd        *cobra.Command


### PR DESCRIPTION
This fix allows us to test the `serve bundle` command using a TLS client.

Previously, we created our own registryClient. We were responsible for configuring TLS for the client, but did not. We now allow helm to create the client for us. Because we previously did not customize the client in any way, we only gain functionality, and lose none.