### PR TITLE
feat: Support repository path prefix for serve bundle

### DIFF
--- a/devbox.json
+++ b/devbox.json
@@ -1,26 +1,30 @@
 {
-  "packages": [
-    "actionlint@latest",
-    "coreutils@latest",
-    "crane@latest",
-    "fd@latest",
-    "ginkgo@latest",
-    "git@latest",
-    "gnused@latest",
-    "gnugrep@latest",
-    "go@latest",
-    "go-task@latest",
-    "gojq@latest",
-    "golangci-lint@latest",
-    "golines@latest",
-    "goreleaser@latest",
-    "gotestsum@latest",
-    "ko@latest",
-    "kubernetes-helm@latest",
-    "pre-commit@latest",
-    "shfmt@latest",
-    "upx@latest",
-    "path:./hack/flakes#go-mod-upgrade",
-    "path:./hack/flakes#govulncheck"
-  ]
+  "packages": {
+    "actionlint":                        "latest",
+    "coreutils":                         "latest",
+    "crane":                             "latest",
+    "darwin.Security": {
+      "version":   "latest",
+      "platforms": ["aarch64-darwin"]
+    },
+    "fd":                                "latest",
+    "ginkgo":                            "latest",
+    "git":                               "latest",
+    "gnused":                            "latest",
+    "gnugrep":                           "latest",
+    "go":                                "latest",
+    "go-task":                           "latest",
+    "gojq":                              "latest",
+    "golangci-lint":                     "latest",
+    "golines":                           "latest",
+    "goreleaser":                        "latest",
+    "gotestsum":                         "latest",
+    "ko":                                "latest",
+    "kubernetes-helm":                   "latest",
+    "pre-commit":                        "latest",
+    "shfmt":                             "latest",
+    "upx":                               "latest",
+    "path:./hack/flakes#go-mod-upgrade": "",
+    "path:./hack/flakes#govulncheck":    ""
+  }
 }

--- a/devbox.lock
+++ b/devbox.lock
@@ -205,6 +205,24 @@
         }
       }
     },
+    "darwin.Security@latest": {
+      "last_modified": "2024-11-16T04:25:12Z",
+      "resolved": "github:NixOS/nixpkgs/34a626458d686f1b58139620a8b2793e9e123bba#darwin.Security",
+      "source": "devbox-search",
+      "version": "11.0",
+      "systems": {
+        "aarch64-linux": {
+          "outputs": [
+            {
+              "name": "out",
+              "path": "/nix/store/nvzqysba0ga8w7b93y2jsfmw6bicrk35-Security-11.0",
+              "default": true
+            }
+          ],
+          "store_path": "/nix/store/nvzqysba0ga8w7b93y2jsfmw6bicrk35-Security-11.0"
+        }
+      }
+    },
     "fd@latest": {
       "last_modified": "2024-11-03T14:18:04Z",
       "resolved": "github:NixOS/nixpkgs/4ae2e647537bcdbb82265469442713d066675275#fd",


### PR DESCRIPTION
This allows for specifying different repositories for a previously
built bundle, very useful when building air-gapped environments to
mimic Harbor which requires inserting a prefix for the project name.
