### PR TITLE
feat: non-container oci images in bundle cmd

### DIFF
--- a/images/manifest.go
+++ b/images/manifest.go
@@ -173,7 +173,7 @@ func indexForSinglePlatformImage(
 		imagePlatformForComparison.Variant = ""
 	}
 
-	if !imagePlatformForComparison.Equals(*v1Platform) {
+	if imagePlatformForComparison.Variant != "" && !imagePlatformForComparison.Equals(*v1Platform) {
 		return nil, fmt.Errorf(
 			"requested image %q does not match requested platform %q (image is for %q)",
 			ref,


### PR DESCRIPTION
https://jira.nutanix.com/browse/NCN-104850

currently the bundle fails on 

- git-operators-manifests
- kommander helm chart
- kommander-application OCI images

with this change the bundle can be built