### PR TITLE
test(e2e): Remove use of deprecated subcommands

### DIFF
--- a/devbox.lock
+++ b/devbox.lock
@@ -290,50 +290,50 @@
       }
     },
     "ginkgo@latest": {
-      "last_modified": "2025-02-07T11:26:36Z",
-      "resolved": "github:NixOS/nixpkgs/d98abf5cf5914e5e4e9d57205e3af55ca90ffc1d#ginkgo",
+      "last_modified": "2025-03-11T17:52:14Z",
+      "resolved": "github:NixOS/nixpkgs/0d534853a55b5d02a4ababa1d71921ce8f0aee4c#ginkgo",
       "source": "devbox-search",
-      "version": "2.22.2",
+      "version": "2.23.0",
       "systems": {
         "aarch64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/gj8hkypjk2lzl5dv52x89sfgg0i6856k-ginkgo-2.22.2",
+              "path": "/nix/store/pi0nyg45m9mr2ap70gh112qv6p63dzn9-ginkgo-2.23.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/gj8hkypjk2lzl5dv52x89sfgg0i6856k-ginkgo-2.22.2"
+          "store_path": "/nix/store/pi0nyg45m9mr2ap70gh112qv6p63dzn9-ginkgo-2.23.0"
         },
         "aarch64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/dr6iqm8qk3a04s0i4s07lclxnycnjws5-ginkgo-2.22.2",
+              "path": "/nix/store/9rh08lc1265m51ivrb1yzf2fhh92qsfx-ginkgo-2.23.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/dr6iqm8qk3a04s0i4s07lclxnycnjws5-ginkgo-2.22.2"
+          "store_path": "/nix/store/9rh08lc1265m51ivrb1yzf2fhh92qsfx-ginkgo-2.23.0"
         },
         "x86_64-darwin": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/4yp3npr5l39r31ab29pnghjv7r7gg6c2-ginkgo-2.22.2",
+              "path": "/nix/store/pi0msn5z2z71wvl6dmm4saj7330xa04b-ginkgo-2.23.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/4yp3npr5l39r31ab29pnghjv7r7gg6c2-ginkgo-2.22.2"
+          "store_path": "/nix/store/pi0msn5z2z71wvl6dmm4saj7330xa04b-ginkgo-2.23.0"
         },
         "x86_64-linux": {
           "outputs": [
             {
               "name": "out",
-              "path": "/nix/store/9xcay9qlzhmnc0jhvyzkblqnbiqlzya8-ginkgo-2.22.2",
+              "path": "/nix/store/lxr489qaf33bk9dfhi5hmri7i1k92f4a-ginkgo-2.23.0",
               "default": true
             }
           ],
-          "store_path": "/nix/store/9xcay9qlzhmnc0jhvyzkblqnbiqlzya8-ginkgo-2.22.2"
+          "store_path": "/nix/store/lxr489qaf33bk9dfhi5hmri7i1k92f4a-ginkgo-2.23.0"
         }
       }
     },
@@ -410,7 +410,7 @@
       }
     },
     "github:NixOS/nixpkgs/nixpkgs-unstable": {
-      "resolved": "github:NixOS/nixpkgs/02032da4af073d0f6110540c8677f16d4be0117f?lastModified=1741037377&narHash=sha256-SvtvVKHaUX4Owb%2BPasySwZsoc5VUeTf1px34BByiOxw%3D"
+      "resolved": "github:NixOS/nixpkgs/573c650e8a14b2faa0041645ab18aed7e60f0c9a?lastModified=1741865919&narHash=sha256-4thdbnP6dlbdq%2BqZWTsm4ffAwoS8Tiq1YResB%2BRP6WE%3D"
     },
     "gnugrep@latest": {
       "last_modified": "2025-02-07T11:26:36Z",

--- a/tasks/build.yaml
+++ b/tasks/build.yaml
@@ -53,7 +53,7 @@ tasks:
         silent: true
       - task: release
         vars:
-          GORELEASER_FLAGS: '--config={{.TEMP_CONFIG}} --release-notes={{.TEMP_RELEASE_NOTES}} --skip=announce,publish,validate'
+          GORELEASER_FLAGS: '--config={{.TEMP_CONFIG}} --release-notes={{.TEMP_RELEASE_NOTES}} --skip=announce,archive,publish,validate'
 
   release-snapshot:
     desc: Builds a snapshot release with goreleaser

--- a/test/e2e/helmbundle/push_bundle_test.go
+++ b/test/e2e/helmbundle/push_bundle_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Push Bundle", func() {
 
 		cmd = helpers.NewCommand(
 			GinkgoT(),
-			func(out output.Output) *cobra.Command { return pushbundle.NewCommand(out, "helm-bundle") },
+			func(out output.Output) *cobra.Command { return pushbundle.NewCommand(out, "bundle") },
 		)
 	})
 
@@ -75,7 +75,7 @@ var _ = Describe("Push Bundle", func() {
 		helpers.WaitForTCPPort(GinkgoT(), "127.0.0.1", port)
 
 		cmd.SetArgs([]string{
-			"--helm-bundle", bundleFile,
+			"--bundle", bundleFile,
 			"--to-registry", fmt.Sprintf("127.0.0.1:%d/charts", port),
 			"--to-registry-insecure-skip-tls-verify",
 		})
@@ -154,7 +154,7 @@ var _ = Describe("Push Bundle", func() {
 		helpers.WaitForTCPPort(GinkgoT(), ipAddr.String(), port)
 
 		cmd.SetArgs([]string{
-			"--helm-bundle", bundleFile,
+			"--bundle", bundleFile,
 			"--to-registry", fmt.Sprintf("%s:%d/charts", ipAddr, port),
 			"--to-registry-insecure-skip-tls-verify",
 		})
@@ -216,7 +216,7 @@ var _ = Describe("Push Bundle", func() {
 		helpers.WaitForTCPPort(GinkgoT(), ipAddr.String(), port)
 
 		cmd.SetArgs([]string{
-			"--helm-bundle", bundleFile,
+			"--bundle", bundleFile,
 			"--to-registry", fmt.Sprintf("%s:%d/charts", ipAddr, port),
 			"--to-registry-ca-cert-file", caCertFile,
 		})
@@ -233,7 +233,7 @@ var _ = Describe("Push Bundle", func() {
 
 	It("Bundle does not exist", func() {
 		cmd.SetArgs([]string{
-			"--helm-bundle", bundleFile,
+			"--bundle", bundleFile,
 			"--to-registry", "127.0.0.1:0/charts",
 			"--to-registry-insecure-skip-tls-verify",
 		})

--- a/test/e2e/helmbundle/serve_bundle_test.go
+++ b/test/e2e/helmbundle/serve_bundle_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Serve Helm Bundle", func() {
 
 		cmd = helpers.NewCommand(GinkgoT(), func(out output.Output) *cobra.Command {
 			var c *cobra.Command
-			c, stopCh = servebundle.NewCommand(out, "helm-bundle")
+			c, stopCh = servebundle.NewCommand(out, "bundle")
 			return c
 		})
 	})
@@ -55,7 +55,7 @@ var _ = Describe("Serve Helm Bundle", func() {
 		port, err := freeport.GetFreePort()
 		Expect(err).NotTo(HaveOccurred())
 		cmd.SetArgs([]string{
-			"--helm-bundle", bundleFile,
+			"--bundle", bundleFile,
 			"--listen-port", strconv.Itoa(port),
 		})
 
@@ -114,7 +114,7 @@ var _ = Describe("Serve Helm Bundle", func() {
 		port, err := freeport.GetFreePort()
 		Expect(err).NotTo(HaveOccurred())
 		cmd.SetArgs([]string{
-			"--helm-bundle", bundleFile,
+			"--bundle", bundleFile,
 			"--listen-address", ipAddr.String(),
 			"--listen-port", strconv.Itoa(port),
 			"--tls-cert-file", certFile,
@@ -184,7 +184,7 @@ var _ = Describe("Serve Helm Bundle", func() {
 
 	It("Bundle does not exist", func() {
 		cmd.SetArgs([]string{
-			"--helm-bundle", bundleFile,
+			"--bundle", bundleFile,
 		})
 
 		Expect(

--- a/test/e2e/imagebundle/import_bundle_test.go
+++ b/test/e2e/imagebundle/import_bundle_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Import Bundle", Label("import"), Serial, func() {
 			c, err := dc.StartContainerWithPlatform(
 				ctx,
 				container.Config{
-					Image:      "ghcr.io/mesosphere/kind-node:v1.28.2",
+					Image:      "ghcr.io/mesosphere/kind-node:v1.32.3",
 					Entrypoint: strslice.StrSlice{"containerd"},
 				},
 				&specs.Platform{OS: opsys, Architecture: arch},

--- a/test/e2e/imagebundle/push_bundle_test.go
+++ b/test/e2e/imagebundle/push_bundle_test.go
@@ -50,7 +50,7 @@ var _ = Describe("Push Bundle", func() {
 
 			cmd = helpers.NewCommand(
 				GinkgoT(),
-				func(out output.Output) *cobra.Command { return pushbundle.NewCommand(out, "image-bundle") },
+				func(out output.Output) *cobra.Command { return pushbundle.NewCommand(out, "bundle") },
 			)
 		})
 
@@ -113,7 +113,7 @@ var _ = Describe("Push Bundle", func() {
 			}
 
 			args := []string{
-				"--image-bundle", bundleFile,
+				"--bundle", bundleFile,
 				"--to-registry", registryHostWithOptionalScheme,
 			}
 			if registryInsecure {
@@ -214,7 +214,7 @@ var _ = Describe("Push Bundle", func() {
 
 		It("Bundle does not exist", func() {
 			cmd.SetArgs([]string{
-				"--image-bundle", bundleFile,
+				"--bundle", bundleFile,
 				"--to-registry", "127.0.0.1:0/charts",
 				"--to-registry-insecure-skip-tls-verify",
 			})
@@ -264,7 +264,7 @@ var _ = Describe("Push Bundle", func() {
 		}`),
 						0o644,
 					)
-					Expect(err).ToNot(HaveOccurred())
+					Expect(err).NotTo(HaveOccurred())
 				})
 
 				It("Success", func() {
@@ -329,7 +329,7 @@ var _ = Describe("Push Bundle", func() {
 
 			It("Successful push with explicit --on-existing-tag=skip flag even though doesn't exist yet", func() {
 				args := []string{
-					"--image-bundle", bundleFile,
+					"--bundle", bundleFile,
 					"--to-registry", registryAddress,
 					"--to-registry-insecure-skip-tls-verify",
 					"--on-existing-tag=skip",
@@ -340,12 +340,12 @@ var _ = Describe("Push Bundle", func() {
 
 				Expect(cmd.Execute()).To(Succeed())
 
-				Expect(outputBuf.String()).To(ContainSubstring("✓"))
+				Expect(outputBuf.String()).NotTo(ContainSubstring("✗"))
 			})
 
 			It("Successful push without on-existing-tag flag (default to overwrite)", func() {
 				args := []string{
-					"--image-bundle", bundleFile,
+					"--bundle", bundleFile,
 					"--to-registry", registryAddress,
 					"--to-registry-insecure-skip-tls-verify",
 					"--image-push-concurrency=4",
@@ -355,12 +355,12 @@ var _ = Describe("Push Bundle", func() {
 
 				Expect(cmd.Execute()).To(Succeed())
 
-				Expect(outputBuf.String()).To(ContainSubstring("✓"))
+				Expect(outputBuf.String()).NotTo(ContainSubstring("✗"))
 			})
 
 			It("Successful push with explicit --on-existing-tag=overwrite", func() {
 				args := []string{
-					"--image-bundle", bundleFile,
+					"--bundle", bundleFile,
 					"--to-registry", registryAddress,
 					"--to-registry-insecure-skip-tls-verify",
 					"--on-existing-tag=overwrite",
@@ -371,12 +371,12 @@ var _ = Describe("Push Bundle", func() {
 
 				Expect(cmd.Execute()).To(Succeed())
 
-				Expect(outputBuf.String()).To(ContainSubstring("✓"))
+				Expect(outputBuf.String()).NotTo(ContainSubstring("✗"))
 			})
 
 			It("Successful push with explicit --on-existing-tag=skip", func() {
 				args := []string{
-					"--image-bundle", bundleFile,
+					"--bundle", bundleFile,
 					"--to-registry", registryAddress,
 					"--to-registry-insecure-skip-tls-verify",
 					"--on-existing-tag=skip",
@@ -387,12 +387,12 @@ var _ = Describe("Push Bundle", func() {
 
 				Expect(cmd.Execute()).To(Succeed())
 
-				Expect(outputBuf.String()).To(ContainSubstring("✓"))
+				Expect(outputBuf.String()).NotTo(ContainSubstring("✗"))
 			})
 
 			It("Failed push with explicit --on-existing-tag=error", func() {
 				args := []string{
-					"--image-bundle", bundleFile,
+					"--bundle", bundleFile,
 					"--to-registry", registryAddress,
 					"--to-registry-insecure-skip-tls-verify",
 					"--on-existing-tag=error",

--- a/test/e2e/imagebundle/serve_bundle_test.go
+++ b/test/e2e/imagebundle/serve_bundle_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Serve Image Bundle", func() {
 
 		cmd = helpers.NewCommand(GinkgoT(), func(out output.Output) *cobra.Command {
 			var c *cobra.Command
-			c, stopCh = servebundle.NewCommand(out, "image-bundle")
+			c, stopCh = servebundle.NewCommand(out, "bundle")
 			return c
 		})
 	})
@@ -56,7 +56,7 @@ var _ = Describe("Serve Image Bundle", func() {
 		port, err := freeport.GetFreePort()
 		Expect(err).NotTo(HaveOccurred())
 		cmd.SetArgs([]string{
-			"--image-bundle", bundleFile,
+			"--bundle", bundleFile,
 			"--listen-port", strconv.Itoa(port),
 		})
 
@@ -110,7 +110,7 @@ var _ = Describe("Serve Image Bundle", func() {
 		port, err := freeport.GetFreePort()
 		Expect(err).NotTo(HaveOccurred())
 		cmd.SetArgs([]string{
-			"--image-bundle", bundleFile,
+			"--bundle", bundleFile,
 			"--listen-address", ipAddr.String(),
 			"--listen-port", strconv.Itoa(port),
 			"--tls-cert-file", certFile,
@@ -176,7 +176,7 @@ var _ = Describe("Serve Image Bundle", func() {
 		port, err := freeport.GetFreePort()
 		Expect(err).NotTo(HaveOccurred())
 		cmd.SetArgs([]string{
-			"--image-bundle", bundleFile,
+			"--bundle", bundleFile,
 			"--listen-address", ipAddr.String(),
 			"--listen-port", strconv.Itoa(port),
 			"--tls-cert-file", certFile,
@@ -225,7 +225,7 @@ var _ = Describe("Serve Image Bundle", func() {
 
 	It("Bundle does not exist", func() {
 		cmd.SetArgs([]string{
-			"--image-bundle", bundleFile,
+			"--bundle", bundleFile,
 		})
 
 		Expect(


### PR DESCRIPTION
`image-bundle` and `helm-bundle` were deprecated a while back in favour of a single `bundle` subcommand so updating e2e to reflect this.