### PR TITLE
feat: go 1.24.2 to fix CVE

### DIFF
--- a/cmd/copy-file-to-pod/go.mod
+++ b/cmd/copy-file-to-pod/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/copy-file-to-pod
 
 go 1.23.2
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require (
 	k8s.io/cli-runtime v0.31.2

--- a/cmd/wait-for-file-to-exist/go.mod
+++ b/cmd/wait-for-file-to-exist/go.mod
@@ -5,7 +5,7 @@ module github.com/nutanix-cloud-native/wait-for-file-to-exist
 
 go 1.23.2
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require github.com/fsnotify/fsnotify v1.7.0
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ module github.com/mesosphere/mindthegap
 
 go 1.23.7
 
-toolchain go1.24.1
+toolchain go1.24.2
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.36.3


### PR DESCRIPTION
Fixes https://pkg.go.dev/vuln/GO-2025-3563.