### PR TITLE
refactor: export PullImagesAndOCIArtifacts function

### DIFF
--- a/cmd/mindthegap/create/bundle/bundle.go
+++ b/cmd/mindthegap/create/bundle/bundle.go
@@ -160,7 +160,7 @@ func NewCommand(out output.Output) *cobra.Command {
 			logs.Warn.SetOutput(out.V(2).InfoWriter())
 
 			if imagesConfigFile != "" || ociArtifactsConfigFile != "" {
-				if err := pullImagesAndOCIArtifacts(
+				if err := PullImagesAndOCIArtifacts(
 					imagesConfig,
 					ociArtifactsConfig,
 					platforms,
@@ -222,7 +222,7 @@ func NewCommand(out output.Output) *cobra.Command {
 	return cmd
 }
 
-func pullImagesAndOCIArtifacts(
+func PullImagesAndOCIArtifacts(
 	imagesConfig config.ImagesConfig,
 	ociArtifactsConfig config.ImagesConfig,
 	platforms flags.Platforms,


### PR DESCRIPTION
export `PullImagesAndOCIArtifacts` func so that it can be consumed in the new catalog CLI