### PR TITLE
fix: Correctly check not found errors in registry storage

### DIFF
--- a/test/e2e/imagebundle/testdata/create-success-busybox.yaml
+++ b/test/e2e/imagebundle/testdata/create-success-busybox.yaml
@@ -1,0 +1,7 @@
+# Copyright 2021 D2iQ, Inc. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+docker.io:
+  images:
+    library/busybox:
+      - 1.37.0-musl


### PR DESCRIPTION
This PR includes 2 commits, the first adding an e2e test that fails before the fix from the second commit is applied.

Details of the fix:

Previously, this was using `os.IsNotExist` error checking, but since the
move to using `ArchiveFS` from `github.com/mholt/archives` this should
have been changed to `errors.Is(err, fs.ErrNotExist)` which is now the
standard way to check filesystem errors with `fs.FS` based filesystems.