### PR TITLE
feat: Improved output for push bundle with non-interative TTY

### DIFF
--- a/test/e2e/imagebundle/push_bundle_test.go
+++ b/test/e2e/imagebundle/push_bundle_test.go
@@ -535,9 +535,9 @@ var _ = Describe("Push Bundle", func() {
 
 				cmd.SetArgs(args)
 
-				Expect(cmd.Execute()).To(HaveOccurred())
-
-				Expect(outputBuf.String()).To(ContainSubstring("✗"))
+				Expect(
+					cmd.Execute(),
+				).To(MatchError(ContainSubstring("image tag already exists in destination registry")))
 			})
 		})
 


### PR DESCRIPTION
This commit outputs the bundle push output better for non-interactive TTY outputs rather than always using the gauge output.

Example output:

```
2025-09-09 10:44:07 INF  • Creating temporary directory...
 ✓ Creating temporary directory
2025-09-09 10:44:07 INF  • Extracting bundle configs from "large-bundle.tar"...
 ✓ Extracting bundle configs from "large-bundle.tar"
2025-09-09 10:44:07 INF  • Parsing image bundle config...
 ✓ Parsing image bundle config
2025-09-09 10:44:07 INF  • Starting temporary Docker registry...
 ✓ Starting temporary Docker registry
2025-09-09 10:44:08 INF  • [1/112] Pushing docker.io/nutanix/ntnx-csi:3.3.4...
2025-09-09 10:44:08 INF  ✓ [1/112] Pushing docker.io/nutanix/ntnx-csi:3.3.4
2025-09-09 10:44:08 INF  • [2/112] Pushing docker.io/calico/node-driver-registrar:v3.29.4...
2025-09-09 10:44:08 INF  ✓ [2/112] Pushing docker.io/calico/node-driver-registrar:v3.29.4
2025-09-09 10:44:08 INF  • [3/112] Pushing docker.io/library/busybox:1...
2025-09-09 10:44:08 INF  ✓ [3/112] Pushing docker.io/library/busybox:1
2025-09-09 10:44:08 INF  • [4/112] Pushing docker.io/calico/kube-controllers:v3.29.4...
2025-09-09 10:44:08 INF  ✓ [4/112] Pushing docker.io/calico/kube-controllers:v3.29.4
2025-09-09 10:44:08 INF  • [5/112] Pushing docker.io/calico/node:v3.29.4...
2025-09-09 10:44:08 INF  ✓ [5/112] Pushing docker.io/calico/node:v3.29.4
```

Gauge is retained on interactive TTY:

```
 ✓ Creating temporary directory
 ✓ Extracting bundle configs from "large-bundle.tar"
 ✓ Parsing image bundle config
 ✓ Starting temporary Docker registry
⢀⡱ Pushing bundled images [=====================>            72/112] (time elapsed 05s)
```