### PR TITLE
fix(cmd/push): use positive bundle markers for push bundle detection (NCN-114493)

### DIFF
--- a/cmd/mindthegap/push/bundle/bundle.go
+++ b/cmd/mindthegap/push/bundle/bundle.go
@@ -4,11 +4,14 @@
 package bundle
 
 import (
+	"archive/tar"
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
+	tarpath "path"
 	"slices"
 	"strings"
 	"sync"
@@ -38,7 +41,6 @@ import (
 	"github.com/mesosphere/mindthegap/docker/ecr"
 	"github.com/mesosphere/mindthegap/docker/registry"
 	"github.com/mesosphere/mindthegap/images"
-	"github.com/mesosphere/mindthegap/images/archive"
 	"github.com/mesosphere/mindthegap/images/authnhelpers"
 	"github.com/mesosphere/mindthegap/images/httputils"
 )
@@ -972,17 +974,36 @@ func mergeIndexesOverwriteExisting(
 // rejectImageArchives returns an error pointing users to
 // `mindthegap push image-archive` if any of the supplied files are
 // OCI image layout or docker-save tarballs rather than mindthegap
-// bundles. Files that Detect cannot classify (e.g. compressed
-// archives, non-tar files, or malformed tars) are ignored here so
-// that downstream processing can surface its own, more specific
-// error message.
+// bundles.
+//
+// Classification is performed by a single streaming tar-header
+// walk per file that records four markers:
+//
+//   - the registry storage tree (any entry whose path starts with
+//     "docker/registry/v2/")
+//   - a bundle config (images.yaml or charts.yaml at the tar root)
+//   - an OCI image layout marker (oci-layout at the tar root)
+//   - a docker-save manifest (manifest.json at the tar root)
+//
+// A file is treated as a mindthegap bundle iff it carries BOTH the
+// storage tree AND at least one bundle config; in that case it is
+// accepted regardless of any image-archive markers it may also
+// carry. Otherwise, if an OCI layout or docker-save marker is
+// present, the file is rejected with a hint pointing at
+// `mindthegap push image-archive`. Files that cannot be classified
+// at all (compressed tarballs, non-tar files, malformed tars) are
+// ignored so that downstream processing can surface its own, more
+// specific error message.
 func rejectImageArchives(paths []string) error {
 	for _, p := range paths {
-		format, err := archive.Detect(p)
+		c, err := classifyBundleCandidate(p)
 		if err != nil {
 			continue
 		}
-		if format == archive.FormatUnknown {
+		if c.isBundle() {
+			continue
+		}
+		if !c.looksLikeImageArchive() {
 			continue
 		}
 		return fmt.Errorf(
@@ -992,4 +1013,77 @@ func rejectImageArchives(paths []string) error {
 		)
 	}
 	return nil
+}
+
+// bundleCandidate records which classification markers a tar file
+// contains. See rejectImageArchives for the precise semantics.
+type bundleCandidate struct {
+	hasStorageTree    bool
+	hasImagesYAML     bool
+	hasChartsYAML     bool
+	hasOCILayout      bool
+	hasDockerManifest bool
+}
+
+func (c bundleCandidate) isBundle() bool {
+	return c.hasStorageTree && (c.hasImagesYAML || c.hasChartsYAML)
+}
+
+func (c bundleCandidate) looksLikeImageArchive() bool {
+	return c.hasOCILayout || c.hasDockerManifest
+}
+
+func (c bundleCandidate) allMarkersSeen() bool {
+	return c.hasStorageTree &&
+		c.hasImagesYAML &&
+		c.hasChartsYAML &&
+		c.hasOCILayout &&
+		c.hasDockerManifest
+}
+
+// storageTreePrefix is the path prefix under which the
+// distribution registry's filesystem storage driver lays out
+// repository data inside a mindthegap bundle. See
+// docker/registry/storage/driver/archive.
+const storageTreePrefix = "docker/registry/v2/"
+
+func classifyBundleCandidate(path string) (bundleCandidate, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return bundleCandidate{}, err
+	}
+	defer f.Close()
+
+	var c bundleCandidate
+	tr := tar.NewReader(f)
+	for {
+		hdr, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			return c, nil
+		}
+		if err != nil {
+			return bundleCandidate{}, err
+		}
+
+		entryName := tarpath.Clean(hdr.Name)
+
+		if strings.HasPrefix(entryName, storageTreePrefix) {
+			c.hasStorageTree = true
+		} else if tarpath.Dir(entryName) == "." {
+			switch entryName {
+			case "images.yaml":
+				c.hasImagesYAML = true
+			case "charts.yaml":
+				c.hasChartsYAML = true
+			case "oci-layout":
+				c.hasOCILayout = true
+			case "manifest.json":
+				c.hasDockerManifest = true
+			}
+		}
+
+		if c.allMarkersSeen() {
+			return c, nil
+		}
+	}
 }

--- a/cmd/mindthegap/push/bundle/detect_test.go
+++ b/cmd/mindthegap/push/bundle/detect_test.go
@@ -4,6 +4,7 @@
 package bundle_test
 
 import (
+	"archive/tar"
 	"bytes"
 	"compress/gzip"
 	"os"
@@ -16,6 +17,40 @@ import (
 	"github.com/mesosphere/mindthegap/cmd/mindthegap/push/bundle"
 	"github.com/mesosphere/mindthegap/images/archive/testutil"
 )
+
+// writeBundleLikeTar writes a tar archive at path containing the
+// supplied entries. Each entry is the tar member name; an entry name
+// ending in "/" is recorded as a directory header (no body).
+func writeBundleLikeTar(tb testing.TB, path string, entries ...string) {
+	tb.Helper()
+	f, err := os.Create(path)
+	if err != nil {
+		tb.Fatalf("create %s: %v", path, err)
+	}
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			tb.Fatalf("close %s: %v", path, cerr)
+		}
+	}()
+	tw := tar.NewWriter(f)
+	for _, name := range entries {
+		isDir := strings.HasSuffix(name, "/")
+		hdr := &tar.Header{Name: name, Mode: 0o644}
+		if isDir {
+			hdr.Typeflag = tar.TypeDir
+			hdr.Mode = 0o755
+		} else {
+			hdr.Typeflag = tar.TypeReg
+			hdr.Size = 0
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			tb.Fatalf("write header %s: %v", name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		tb.Fatalf("close tar: %v", err)
+	}
+}
 
 func TestPushBundleRejectsImageArchive(t *testing.T) {
 	tmp := t.TempDir()
@@ -106,5 +141,135 @@ func TestPushBundleDoesNotInterceptUnclassifiableFile(t *testing.T) {
 	}
 	if strings.Contains(err.Error(), "push image-archive") {
 		t.Fatalf("detection hook should not intercept unclassifiable files: %v", err)
+	}
+}
+
+// TestPushBundleAcceptsBundleWithImageArchiveMarkers verifies that
+// a tar carrying both the mindthegap bundle markers (registry
+// storage tree under docker/registry/v2/ AND at least one of
+// images.yaml or charts.yaml at the tar root) is not redirected to
+// "push image-archive" even if it also happens to carry an
+// oci-layout or manifest.json file at the tar root.
+//
+// Bundle identity is a positive property; image-archive markers
+// alone must not override it. Regression for NCN-114493.
+func TestPushBundleAcceptsBundleWithImageArchiveMarkers(t *testing.T) {
+	cases := []struct {
+		name    string
+		entries []string
+	}{
+		{
+			name: "images.yaml plus storage tree plus oci-layout at root",
+			entries: []string{
+				"oci-layout",
+				"images.yaml",
+				"docker/registry/v2/repositories/foo/_manifests/tags/v1/current/link",
+			},
+		},
+		{
+			name: "charts.yaml plus storage tree plus manifest.json at root",
+			entries: []string{
+				"manifest.json",
+				"charts.yaml",
+				"docker/registry/v2/repositories/foo/_manifests/tags/v1/current/link",
+			},
+		},
+		{
+			name: "both bundle configs plus storage tree plus both image-archive markers",
+			entries: []string{
+				"oci-layout",
+				"manifest.json",
+				"images.yaml",
+				"charts.yaml",
+				"docker/registry/v2/repositories/foo/_manifests/tags/v1/current/link",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			bundlePath := filepath.Join(tmp, "image-bundle.tar")
+			writeBundleLikeTar(t, bundlePath, tc.entries...)
+
+			buf := &bytes.Buffer{}
+			out := output.NewNonInteractiveShell(buf, buf, 0)
+			cmd := bundle.NewCommand(out, "bundle")
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			cmd.SetArgs([]string{
+				"--bundle", bundlePath,
+				"--to-registry", "registry.invalid:1",
+			})
+
+			err := cmd.Execute()
+			if err == nil {
+				return
+			}
+			if strings.Contains(err.Error(), "push image-archive") {
+				t.Fatalf("detection hook misclassified bundle as image archive: %v", err)
+			}
+		})
+	}
+}
+
+// TestPushBundleRedirectsWhenBundleMarkersIncomplete verifies that
+// a tar carrying image-archive markers at the tar root but missing
+// either the registry storage tree or both of images.yaml /
+// charts.yaml is still redirected to "push image-archive". This
+// guards against accidentally widening bundle acceptance: both
+// bundle markers must be present together.
+func TestPushBundleRedirectsWhenBundleMarkersIncomplete(t *testing.T) {
+	cases := []struct {
+		name    string
+		entries []string
+	}{
+		{
+			name: "oci-layout plus images.yaml but no storage tree",
+			entries: []string{
+				"oci-layout",
+				"images.yaml",
+			},
+		},
+		{
+			name: "oci-layout plus storage tree but no config file",
+			entries: []string{
+				"oci-layout",
+				"docker/registry/v2/repositories/foo/_manifests/tags/v1/current/link",
+			},
+		},
+		{
+			name: "manifest.json plus charts.yaml but no storage tree",
+			entries: []string{
+				"manifest.json",
+				"charts.yaml",
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			archivePath := filepath.Join(tmp, "archive.tar")
+			writeBundleLikeTar(t, archivePath, tc.entries...)
+
+			buf := &bytes.Buffer{}
+			out := output.NewNonInteractiveShell(buf, buf, 0)
+			cmd := bundle.NewCommand(out, "bundle")
+			cmd.SilenceUsage = true
+			cmd.SilenceErrors = true
+			cmd.SetArgs([]string{
+				"--bundle", archivePath,
+				"--to-registry", "registry.invalid:1",
+			})
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), "push image-archive") {
+				t.Fatalf("expected detection hook to redirect to push image-archive, got: %v", err)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

Fixes a misclassification introduced in NCN-113655: `push bundle`'s detection hook treats any tarball whose root contains an `oci-layout` or `manifest.json` as an image archive, ignoring whether the file is actually a valid mindthegap bundle. A bundle whose tar root surfaces those files (today incidentally, in future potentially by design) is silently redirected to `push image-archive` instead of being pushed.

Replace negative identification with positive bundle identification. A tar is a mindthegap bundle iff it carries **both**:

- the registry storage tree (any entry path starting with `docker/registry/v2/`), **and**
- at least one of `images.yaml` or `charts.yaml` at the tar root

If both are present, the file is accepted regardless of any image-archive markers it may also carry. Only when bundle markers are absent do `oci-layout` / `manifest.json` at the tar root trigger the existing "use `push image-archive` instead" hint. Unclassifiable files (compressed tarballs, non-tar files, malformed tars) continue to fall through to existing downstream handlers (this preserves the `compressed tar archives (.tar.gz) are not supported` error path).

Implementation:

- New `classifyBundleCandidate` does a single tar-header walk recording four markers, with early-exit once all four are seen.
- Detection now lives entirely within `cmd/mindthegap/push/bundle/bundle.go`; the `images/archive` dependency is dropped from this package so `images/archive` stays a general-purpose OCI/docker reader with no mindthegap awareness.

## Test plan

- [x] `go test ./cmd/mindthegap/push/bundle/... -run TestPushBundle -v` — all existing tests still pass (`RejectsImageArchive`, `RejectsDockerArchive`, `DoesNotInterceptUnclassifiableFile`, plus the `WithRegistryCredentials` / `WithRegistryCACertificateFile` / `WithRegistrySkipTLSVerify` / `WithChaining` opts suites).
- [x] New `TestPushBundleAcceptsBundleWithImageArchiveMarkers` (3 subtests) — covers the regression: bundles with extra image-archive markers at the tar root are accepted.
- [x] New `TestPushBundleRedirectsWhenBundleMarkersIncomplete` (3 subtests) — guards against widening: image-archive markers + only one of the two required bundle markers still redirects to `push image-archive`.
- [x] `task test:unit` — 164 tests pass.

Refs: <https://jira.nutanix.com/browse/NCN-114493>